### PR TITLE
BUG: Problem with raw2.github.com

### DIFF
--- a/windows_build_qt.ps1
+++ b/windows_build_qt.ps1
@@ -59,7 +59,7 @@ If (Test-Path $qtBuildScriptFile)
   {
   Remove-Item $qtBuildScriptFile
   }
-$url = ('https://raw2.github.com/jcfr/qt-easy-build/' + $qtBuildScriptVersion + '/cmake/' + $qtBuildScriptName)
+$url = ('https://raw.githubusercontent.com/jcfr/qt-easy-build/' + $qtBuildScriptVersion + '/cmake/' + $qtBuildScriptName)
 Write-Host "Download $url"
 Download-File $url $qtBuildScriptFile
 


### PR DESCRIPTION
It seems that the website for raw files is now raw.githubusercontent.com
I was unable to find information to know if this is a permanent modification or if raw2.github.com is just temporarily down.
