### PR TITLE
UPD : Qt 4.8.7 + curl download of Qt

### DIFF
--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -45,15 +45,17 @@ cd ..
 cwd=$(pwd)
 
 cd qt && \
-rm -rf qt-everywhere-opensource-src-4.8.6 && \
-rm -rf qt-everywhere-opensource-build-4.8.6 && \
-mkdir qt-everywhere-opensource-build-4.8.6 && \
-md5=`md5sum ./qt-everywhere-opensource-src-4.8.6.tar.gz | awk '{ print $1 }'` &&
-[ $md5 == "2edbe4d6c2eff33ef91732602f3518eb" ] ||
+rm -f qt-everywhere-opensource-src-4.8.7.tar.gz
+rm -rf qt-everywhere-opensource-src-4.8.7 && \
+rm -rf qt-everywhere-opensource-build-4.8.7 && \
+mkdir qt-everywhere-opensource-build-4.8.7 && \
+curl -OL http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz
+md5=`md5sum ./qt-everywhere-opensource-src-4.8.7.tar.gz | awk '{ print $1 }'` &&
+[ $md5 == "d990ee66bf7ab0c785589776f35ba6ad" ] ||
   ( echo "MD5 mismatch. Problem downloading Qt" ; exit 1; ) &&
-tar -xzvf qt-everywhere-opensource-src-4.8.6.tar.gz && \
-cd qt-everywhere-opensource-src-4.8.6 && \
-./configure -prefix ../qt-everywhere-opensource-build-4.8.6/  \
+tar -xzvf qt-everywhere-opensource-src-4.8.7.tar.gz && \
+cd qt-everywhere-opensource-src-4.8.7 && \
+./configure -prefix ../qt-everywhere-opensource-build-4.8.7/  \
   -release -opensource -confirm-license -no-qt3support        \
   -webkit -nomake examples -nomake demos                      \
   -openssl -I $cwd/openssl-1.0.1h/include \
@@ -105,10 +107,10 @@ cwd=$(pwd)
 rm -f openssl-1.0.1h.tar.gz && \
 rm -rf openssl-1.0.1h/ && \
 curl -O http://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz && \
-tar -xzvf openssl-1.0.1h.tar.gz && \
 md5=`md5 ./openssl-1.0.1h.tar.gz | awk '{ print $4 }'` &&
 [ $md5 == "8d6d684a9430d5cc98a62a5d8fbda8cf" ] ||
   ( echo "MD5 mismatch. Problem downloading OpenSSL" ; exit 1; ) &&
+tar -xzvf openssl-1.0.1h.tar.gz && \
 cd openssl-1.0.1h/  && \
 export KERNEL_BITS=64 && \
 ./config zlib -lzlib -L$cwd/zlib-install/lib shared && \
@@ -124,15 +126,17 @@ cd ..
 
 cwd=$(pwd)
 
-rm -rf qt-everywhere-opensource-src-4.8.6 && \
-rm -rf qt-everywhere-opensource-build-4.8.6 && \
-mkdir qt-everywhere-opensource-build-4.8.6 && \
-md5=`md5 ./qt-everywhere-opensource-src-4.8.6.tar.gz | awk '{ print $4 }'` &&
-[ $md5 == "2edbe4d6c2eff33ef91732602f3518eb" ] ||
+rm -f qt-everywhere-opensource-src-4.8.7.tar.gz
+rm -rf qt-everywhere-opensource-src-4.8.7 && \
+rm -rf qt-everywhere-opensource-build-4.8.7 && \
+mkdir qt-everywhere-opensource-build-4.8.7 && \
+curl -OL http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz
+md5=`md5 ./qt-everywhere-opensource-src-4.8.7.tar.gz | awk '{ print $4 }'` &&
+[ $md5 == "d990ee66bf7ab0c785589776f35ba6ad" ] ||
   ( echo "MD5 mismatch. Problem downloading Qt" ; exit 1; ) &&
-tar -xzvf qt-everywhere-opensource-src-4.8.6.tar.gz && \
-cd qt-everywhere-opensource-src-4.8.6 && \
-./configure -prefix ../qt-everywhere-opensource-build-4.8.6/  \
+tar -xzvf qt-everywhere-opensource-src-4.8.7.tar.gz && \
+cd qt-everywhere-opensource-src-4.8.7 && \
+./configure -prefix ../qt-everywhere-opensource-build-4.8.7/  \
   -release -opensource -confirm-license -no-qt3support        \
   -webkit -arch x86_64  -nomake examples -nomake demos        \
   -sdk $sysroot                         \


### PR DESCRIPTION
- use of Qt 4.8.7 offering a better support with Mac OS X 10.10 Yosemite [1]
- update of the md5 hash of qt-everywhere-opensource-src-4.8.7.tar.gz [2]
- use of "curl -OL", the '-L' flag allowing redirection, to directly ddl the archive sources to Qt 4.8.7
- for Mac, do extraction of openssl-1.0.1h.tar.gz  after md5 verification, not before

[1] https://blog.qt.io/blog/2015/05/26/qt-4-8-7-released/
[2] http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz.mirrorlist
