### PR TITLE
BUG: Remove wrong command

### DIFF
--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -44,7 +44,6 @@ cd ..
 
 cwd=$(pwd)
 
-cd qt && \
 rm -f qt-everywhere-opensource-src-4.8.7.tar.gz
 rm -rf qt-everywhere-opensource-src-4.8.7 && \
 rm -rf qt-everywhere-opensource-build-4.8.7 && \


### PR DESCRIPTION
Corrects following error :
`cd: qt: No such file or directory`
