### PR TITLE
Fix jom use

### DIFF
--- a/cmake/build_qt_with_openssl.cmake
+++ b/cmake/build_qt_with_openssl.cmake
@@ -88,7 +88,16 @@ message(STATUS "OPENSSL_LIB_DIR: ${OPENSSL_LIB_DIR}")
 get_filename_component(_archive_name ${QT_URL} NAME)
 set(QT_FILE "${DEST_DIR}/${_archive_name}")
 message(STATUS "QT_BUILD_DIR: ${QT_BUILD_DIR}")
-find_program(JOM_EXECUTABLE jom)
+set(ChocolateyInstall_DIR $ENV{ChocolateyInstall})
+if(NOT EXISTS "${ChocolateyInstall_DIR}")
+  message(FATAL_ERROR "Could not find the ChocolateyInstall environment variable."
+    " Something must have gone wrong with the chocolatey installation."
+    " Aborting.")
+  return()
+endif()
+# Use the jom the original jom, not the chocolatey one. The latter does not work.
+find_program(JOM_EXECUTABLE jom
+  HINTS ${ChocolateyInstall_DIR}/lib/jom/content)
 message(STATUS "JOM_EXECUTABLE:${JOM_EXECUTABLE}")
 
 if(NOT EXISTS ${DEST_DIR})


### PR DESCRIPTION
Jom stopped working and would fail with the following message:
"jom: Can't connect to job server: Cannot determine jobserver name."

It seems that chocolatey copy/pastes jom using shimgen: https://github.com/chocolatey/shimgen
a closed-source project and that it breaks jom.
However, using the original jom that chocolatey installs works fine. So we
do that instead. To get the path to the original jom, we use the environment
variable ChocolateyInstall that chocolatey sets when installed.
