### PR TITLE
Unix build fixes

### DIFF
--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -21,8 +21,8 @@ cmake -DCMAKE_BUILD_TYPE:STRING=Release \
        ../zlib && \
 make -j4 && \
 make install && \
-cp zlib-install/lib/libzlib.a zlib-install/lib/libz.a && \
-cd ..
+cd .. && \
+cp zlib-install/lib/libzlib.a zlib-install/lib/libz.a
 
 # Build OpenSSL
 
@@ -98,8 +98,8 @@ cd zlib-build  && \
        ../zlib && \
 make -j4 && \
 make install && \
-cp zlib-install/lib/libzlib.a zlib-install/lib/libz.a && \
-cd ..
+cd .. && \
+cp zlib-install/lib/libzlib.a zlib-install/lib/libz.a
 
 # Build OpenSSL
 

--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -30,7 +30,7 @@ cwd=$(pwd)
 
 rm -f openssl-1.0.1h.tar.gz && \
 rm -rf openssl-1.0.1h/ && \
-wget http://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz && \
+wget https://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz && \
 md5=`md5sum ./openssl-1.0.1h.tar.gz | awk '{ print $1 }'` &&
 [ $md5 == "8d6d684a9430d5cc98a62a5d8fbda8cf" ] ||
   ( echo "MD5 mismatch. Problem downloading OpenSSL" ; exit 1; ) &&
@@ -107,7 +107,7 @@ cwd=$(pwd)
 
 rm -f openssl-1.0.1h.tar.gz && \
 rm -rf openssl-1.0.1h/ && \
-curl -O http://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz && \
+curl -OL https://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz && \
 md5=`md5 ./openssl-1.0.1h.tar.gz | awk '{ print $4 }'` &&
 [ $md5 == "8d6d684a9430d5cc98a62a5d8fbda8cf" ] ||
   ( echo "MD5 mismatch. Problem downloading OpenSSL" ; exit 1; ) &&

--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -124,6 +124,7 @@ cd ..
 
 
 # Build Qt
+# Patch linked from thread: https://github.com/Homebrew/legacy-homebrew/issues/40585
 
 cwd=$(pwd)
 
@@ -135,6 +136,7 @@ curl -OL http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-open
 md5=`md5 ./qt-everywhere-opensource-src-4.8.7.tar.gz | awk '{ print $4 }'` &&
 [ $md5 == "d990ee66bf7ab0c785589776f35ba6ad" ] ||
   ( echo "MD5 mismatch. Problem downloading Qt" ; exit 1; ) &&
+curl https://gist.githubusercontent.com/ejtttje/7163a9ced64f12ae9444/raw | patch -p1 && \
 tar -xzvf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 cd qt-everywhere-opensource-src-4.8.7 && \
 ./configure -prefix ../qt-everywhere-opensource-build-4.8.7/  \


### PR DESCRIPTION
This fixes the Unix build instructions in several places. For example, before these changes, on Mac:
- `cp` step failed for zlib
- OpenSSL source failed to download
- Qt 4.8.7 failed to compile
