### PR TITLE
Update Build-qt.txt

### DIFF
--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -15,7 +15,7 @@ mkdir zlib-install  && \
 mkdir zlib-build  && \
 git clone git://github.com/commontk/zlib.git  && \
 cd zlib-build  && \
-cmake -DCMAKE_BUILD_TYPE:STRING=Release \
+"$cmake" -DCMAKE_BUILD_TYPE:STRING=Release \
        -DZLIB_MANGLE_PREFIX:STRING=slicer_zlib_ \
        -DCMAKE_INSTALL_PREFIX:PATH=$cwd/zlib-install \
        ../zlib && \


### PR DESCRIPTION
Added explicit "$cmake" to the Linux zlib build.  It's currently being used in the [MacOSX zlib build](https://github.com/jcfr/qt-easy-build/blob/4.8.7/Build-qt.txt#L92).  (Was it omitted from the [Linux zlib build](https://github.com/jcfr/qt-easy-build/blob/4.8.7/Build-qt.txt#L18) on purpose?)