### PR TITLE
Build-qt.sh fixes and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 
 # except for .gitignore
 !.gitignore
+
+# Libraries
+openssl-*
+qt-everywhere-opensource-*
+zlib*

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -17,7 +17,7 @@ Options:
   -h             Display this help and exit.
   -j             Number of threads to compile tools. [default: 1]
   -m             Path for cmake.
-  -q             Installation directory for Qt. [default: /usr/local/Trolltech/Qt-4.8.7/]
+  -q             Installation directory for Qt. [default: qt-everywhere-opensource-build-4.8.7]
 
 MacOS only:
   -a             Set OSX architectures. (expected values: x86_64 or i386) [default: x86_64]
@@ -183,11 +183,12 @@ echo "Build Qt"
 
 cwd=$(pwd)
 
-if [[ -n $install_dir ]]
+if [[ -z $install_dir ]]
 then
-  mkdir qt-everywhere-opensource-build-4.8.7
-  qt_install_dir_options="-prefix ../qt-everywhere-opensource-build-4.8.7/"
+  install_dir="$cwd/qt-everywhere-opensource-build-4.8.7"
+  mkdir $install_dir
 fi
+qt_install_dir_options="-prefix $install_dir"
 
 tar -xzvf qt-everywhere-opensource-src-4.8.7.tar.gz
 cd qt-everywhere-opensource-src-4.8.7

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -213,6 +213,7 @@ fi
   -release -opensource -confirm-license -no-qt3support        \
   -webkit -nomake examples -nomake demos                      \
   -silent                                                     \
+  -no-phonon                                                  \
   -openssl -I $cwd/openssl-1.0.1h/include                     \
   ${qt_macos_options}                                         \
   -L $cwd/openssl-1.0.1h

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -176,7 +176,7 @@ echo "Build OpenSSL"
 
 cwd=$(pwd)
 
-tar -xzvf openssl-1.0.1h.tar.gz
+tar -xzf openssl-1.0.1h.tar.gz
 cd openssl-1.0.1h/
 ./config zlib -I$cwd/zlib-install/include -L$cwd/zlib-install/lib shared
 make -j $nbthreads build_libs
@@ -202,7 +202,7 @@ then
 fi
 qt_install_dir_options="-prefix $install_dir"
 
-tar -xzvf qt-everywhere-opensource-src-4.8.7.tar.gz
+tar -xzf qt-everywhere-opensource-src-4.8.7.tar.gz
 cd qt-everywhere-opensource-src-4.8.7
 # If MacOS, patch linked from thread: https://github.com/Homebrew/legacy-homebrew/issues/40585
 if [ "$(uname)" == "Darwin" ]
@@ -212,6 +212,7 @@ fi
 ./configure $qt_install_dir_options                           \
   -release -opensource -confirm-license -no-qt3support        \
   -webkit -nomake examples -nomake demos                      \
+  -silent                                                     \
   -openssl -I $cwd/openssl-1.0.1h/include                     \
   ${qt_macos_options}                                         \
   -L $cwd/openssl-1.0.1h

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 show_help() {
 cat << EOF

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -97,9 +97,15 @@ fi
 
 # Download archives (Qt, and openssl
 echo "Download openssl"
-curl -OL https://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz
+if ! [ -f openssl-1.0.1h.tar.gz ]
+then
+  curl -OL https://packages.kitware.com/download/item/6173/openssl-1.0.1h.tar.gz
+fi
 echo "Download Qt"
-curl -OL http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz
+if ! [ -f qt-everywhere-opensource-src-4.8.7.tar.gz ]
+then
+  curl -OL http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz
+fi
 
 # Check if building on MacOS or Linux
 # And verifies downloaded archives accordingly

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -22,7 +22,7 @@ Options:
 MacOS only:
   -a             Set OSX architectures. (expected values: x86_64 or i386) [default: x86_64]
   -d             OSX deployment target. [default: 10.6]
-  -s             OSX sysroot. [default: /Developer/SDKs/MacOSX10.6.sdk]
+  -s             OSX sysroot. [default: result of 'xcrun --show-sdk-path']
 EOF
 }
 clean=0
@@ -110,7 +110,11 @@ then
   fi
   if [[ -z $osx_sysroot ]]
   then
-    sysroot=/Developer/SDKs/MacOSX10.6.sdk
+    osx_sysroot=$(xcrun --show-sdk-path)
+  fi
+  if [[ -z $osx_sysroot ]]
+  then
+    osx_sysroot=/Developer/SDKs/MacOSX10.6.sdk
   fi
   if [[ -z $osx_architecture ]]
   then


### PR DESCRIPTION
- Fix installation directory option
- Fix and enhance OS X sysroot option
- Exit when a command fails
- Avoid redownloading libraries when running multiple times, such as during testing
- Make output quieter so that errors are more apparent
- Disable phonon to support building with OS X 10.12 SDK
- Move library versions to configuration variables