### PR TITLE
Use shadow build to keep source directory clean

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -349,9 +349,9 @@ if [[ ! -d $src_dir ]]
 then
   tar --no-same-owner -xf $deps_dir/$qt_archive
 fi
-cd $src_dir
+cd $install_dir
 
-./configure $qt_install_dir_options                           \
+$src_dir/configure $qt_install_dir_options                           \
   -release -opensource -confirm-license \
   -c++std c++11 \
   -nomake examples \


### PR DESCRIPTION
Run configure in $install_dir so that the source directory stays clean.

x-ref: https://wiki.qt.io/Qt_shadow_builds