### PR TITLE
Add Windows support for Qt 5.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,57 +25,55 @@ Windows
 1. Open desired Visual Studio Command Prompt (for 64 bit Qt, use the 64 bit Command Prompt, for 32 bit Qt, use the 32 bit Command Prompt)
 2. Paste the corresponding text from the box below and press enter.
 
+Supported Configurations:
+
+| Qt 5.10.0                               |
+| ----------------------------------------|
+| win32-msvc2017 w/openssl                |
+| win32-msvc2015 w/openssl                |
+| win32-msvc2013 w/openssl w/o qtwebengine|
+
+* Visual Studio 2017 64-bit Release
+
+```PowerShell
+@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2017';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/5.10.0/windows_build_qt.ps1'))"
+```
+
+* Visual Studio 2017 64-bit Debug
+
+```PowerShell
+@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2017';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/5.10.0/windows_build_qt.ps1'))"
+```
+
+* Visual Studio 2015 64-bit Release
+
+```PowerShell
+@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2015';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/5.10.0/windows_build_qt.ps1'))"
+```
+
+* Visual Studio 2015 64-bit Debug
+
+```PowerShell
+@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2015';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/5.10.0/windows_build_qt.ps1'))"
+```
+
 * Visual Studio 2013 64-bit Release
 
 ```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2013';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
+@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2013';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/5.10.0/windows_build_qt.ps1'))"
 ```
 
 * Visual Studio 2013 64-bit Debug
 
 ```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2013';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
-```
-
-* Visual Studio 2012 64-bit Release
-
-```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2012';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
-```
-
-* Visual Studio 2012 64-bit Debug
-
-```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2012';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
-```
-
-* Visual Studio 2010 64-bit Release
-
-```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2010';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
-```
-
-* Visual Studio 2010 64-bit Debug
-
-```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2010';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
-```
-
-* Visual Studio 2008 64-bit Release
-
-```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Release';$qtPlatform='win32-msvc2008';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
-```
-
-* Visual Studio 2008 64-bit Debug
-
-```PowerShell
-@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2008';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/4.8.7/windows_build_qt.ps1'))"
+@powershell -Command "$destDir='C:\D\Support';$buildType='Debug';$qtPlatform='win32-msvc2013';$bits='64';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/jcfr/qt-easy-build/5.10.0/windows_build_qt.ps1'))"
 ```
 
 ### Notes ###
 
 * the minimum glibc version [supported by QtWebEngine is 2.17](https://github.com/qt/qtwebengine/commit/6d9fe6ba35024efc8e0a26435b51e25aa3ea7f09#diff-fb760d5130a8d1bf9c6f4be03ebcdc20). This excludes building QtWebEngine on less than CentOS 7, for example (local glibc version may be checked with `ldd --version`).
+
+* the minimum MSVC version [supported by QtWebEngine is 2015](https://github.com/qt/qtwebengine/commit/3b4ca800635003844ed54d2e056ee3f6559b108b#diff-355124f6d939bcdc011b1a18983461d4). This excludes building QtWebEngine on less than MSVC2015
 
 * `buildType` can be set to either 'Release' or 'Debug'
 

--- a/cmake/QEBGetOpenSSLBinariesDownloadURL.cmake
+++ b/cmake/QEBGetOpenSSLBinariesDownloadURL.cmake
@@ -1,4 +1,3 @@
-
 #
 # qeb_get_openssl_binaries_download_url(bits qt_platform url_var md5_var)
 #
@@ -10,8 +9,8 @@
 # Acceptable input values:
 #
 # * bits           : 32 or 64
-# * qt_platform    : win32-msvc2008, win32-msvc2010, win32-msvc2012 or win32-msvc2013
-# * openssl_version: 1.0.1h
+# * qt_platform    : win32-msvc2013, win32-msvc2015 or win32-msvc2017
+# * openssl_version: 1.0.2k
 #
 #
 # Archive layout:
@@ -37,20 +36,20 @@
 #
 # For example, calling the following:
 #
-#  qeb_get_openssl_binaries_download_url(64 "win32-msvc2008" "1.0.1h" OPENSSL_URL OPENSSL_MD5)
+#  qeb_get_openssl_binaries_download_url(64 "win32-msvc2017" "1.0.2k" OPENSSL_URL OPENSSL_MD5)
 #  message("OPENSSL_URL: ${OPENSSL_URL}")
 #  message("OPENSSL_MD5: ${OPENSSL_MD5}")
 #
 # will display:
 #
-#  OPENSSL_URL: http://packages.kitware.com/download/item/6090/OpenSSL_1_0_1h-install-msvc1500-64.tar.gz
-#  OPENSSL_MD5: dab0c026ab56fd0fbfe2843d14218fad
+#  OPENSSL_URL: http://packages.kitware.com/download/bitstream/10378/OpenSSL_1_0_2k-install-msvc1910-64.tar.gz
+#  OPENSSL_MD5: 8b49bb670f8b12444a502cd2e954f5d3
 #
 #
 # Notes:
 #
 # OpenSSL archives are downloaded from http://packages.kitware.com and have been
-# built using script https://gist.github.com/jcfr/6030240.
+# built using script https://gist.github.com/jamesobutler/f29a8edfe70cbdf7c3d94d25c20e1dce.
 #
 function(qeb_get_openssl_binaries_download_url bits qt_platform openssl_version url_var md5_var)
 
@@ -58,41 +57,33 @@ function(qeb_get_openssl_binaries_download_url bits qt_platform openssl_version 
 
   # XXX If more than one version of OpenSSL should effectively be supported, the
   #     following code should be refactored.
-  if(NOT openssl_version STREQUAL "1.0.1h")
+  if(NOT openssl_version STREQUAL "1.0.2k")
     message(FATAL_ERROR "${_error_msg}")
   endif()
 
-  if(QT_PLATFORM STREQUAL "win32-msvc2013")
+  if(QT_PLATFORM STREQUAL "win32-msvc2017")
     if(BITS EQUAL 64)
-      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/8915/OpenSSL_1_0_1h-install-msvc1800-64.tar.gz")
-      set(OPENSSL_MD5 "7aefdd94babefbe603cca48ff86da768")
+      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/10378/OpenSSL_1_0_2k-install-msvc1910-64.tar.gz")
+      set(OPENSSL_MD5 "8b49bb670f8b12444a502cd2e954f5d3")
     else()
-      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/8918/OpenSSL_1_0_1h-install-msvc1800-32.tar.gz")
-      set(OPENSSL_MD5 "f10ceb422ab37f2b0bd5e225c74fd1d4")
+      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/10377/OpenSSL_1_0_2k-install-msvc1910-32.tar.gz")
+      set(OPENSSL_MD5 "26de05c7743b4eddd3a36700e69b3f53")
     endif()
-  elseif(QT_PLATFORM STREQUAL "win32-msvc2012")
+  elseif(QT_PLATFORM STREQUAL "win32-msvc2015")
     if(BITS EQUAL 64)
-      set(OPENSSL_URL "http://packages.kitware.com/download/item/6099/OpenSSL_1_0_1h-install-msvc1600-64.tar.gz")
-      set(OPENSSL_MD5 "b54a0a4b396397fdf96e55f0f7345dd1")
+      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/10379/OpenSSL_1_0_2k-install-msvc1900-64.tar.gz")
+      set(OPENSSL_MD5 "757e9e54dbf114074f4f625fba501112")
     else()
-      set(OPENSSL_URL "http://packages.kitware.com/download/item/6096/OpenSSL_1_0_1h-install-msvc1600-32.tar.gz")
-      set(OPENSSL_MD5 "e80269ae7969276977a342cccc1df5c5")
+      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/10380/OpenSSL_1_0_2k-install-msvc1900-32.tar.gz")
+      set(OPENSSL_MD5 "24f29cdb2e82e4a3f439dc46361ee5a1")
     endif()
-  elseif(QT_PLATFORM STREQUAL "win32-msvc2010")
+  elseif(QT_PLATFORM STREQUAL "win32-msvc2013")
     if(BITS EQUAL 64)
-      set(OPENSSL_URL "http://packages.kitware.com/download/item/6099/OpenSSL_1_0_1h-install-msvc1600-64.tar.gz")
-      set(OPENSSL_MD5 "b54a0a4b396397fdf96e55f0f7345dd1")
+      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/10381/OpenSSL_1_0_2k-install-msvc1800-64.tar.gz")
+      set(OPENSSL_MD5 "969a28cb20407feb274a3eccdf0d1c40")
     else()
-      set(OPENSSL_URL "http://packages.kitware.com/download/item/6096/OpenSSL_1_0_1h-install-msvc1600-32.tar.gz")
-      set(OPENSSL_MD5 "e80269ae7969276977a342cccc1df5c5")
-    endif()
-  elseif(QT_PLATFORM STREQUAL "win32-msvc2008")
-    if(BITS EQUAL 64)
-      set(OPENSSL_URL "http://packages.kitware.com/download/item/6090/OpenSSL_1_0_1h-install-msvc1500-64.tar.gz")
-      set(OPENSSL_MD5 "dab0c026ab56fd0fbfe2843d14218fad")
-    else()
-      set(OPENSSL_URL "http://packages.kitware.com/download/item/6093/OpenSSL_1_0_1h-install-msvc1500-32.tar.gz")
-      set(OPENSSL_MD5 "8b110bb48063223c3b9f3a99f1fa9067")
+      set(OPENSSL_URL "http://packages.kitware.com/download/bitstream/10382/OpenSSL_1_0_2k-install-msvc1800-32.tar.gz")
+      set(OPENSSL_MD5 "79c42146295b4dbfd4dbc53fff0b6fb3")
     endif()
   else()
     message(FATAL_ERROR "${_error_msg}")

--- a/cmake/QEBQt5ExternalProjectCommand.cmake
+++ b/cmake/QEBQt5ExternalProjectCommand.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11.0)
 
 foreach(p
   CMP0054 # CMake 3.1
@@ -9,7 +9,7 @@ foreach(p
 endforeach()
 
 #
-# QEBQt4ExternalProjectCommands
+# QEBQt5ExternalProjectCommands
 #
 
 set(usage
@@ -73,14 +73,15 @@ if("${MODE}" STREQUAL "configure")
   string(TOLOWER ${QT_BUILD_TYPE} QT_BUILD_TYPE)
 
   execute_process(
-    COMMAND ${QT_BUILD_DIR}/configure.exe
-      -opensource -confirm-license
-      -shared
-      -platform ${QT_PLATFORM} -${QT_BUILD_TYPE}
-      -webkit
-      -openssl -I ${OPENSSL_INCLUDE_DIR} -L ${OPENSSL_LIBRARY_DIR}
+    COMMAND ${QT_BUILD_DIR}/configure.bat
+      -release -opensource -confirm-license
+      -c++std c++11
       -nomake examples
-      -nomake demos
+      -nomake tests
+      -silent
+      -openssl -I ${OPENSSL_INCLUDE_DIR} -L ${OPENSSL_LIBRARY_DIR}
+      -platform ${QT_PLATFORM} -${QT_BUILD_TYPE}
+      
     WORKING_DIRECTORY ${QT_BUILD_DIR}
     RESULT_VARIABLE result_var
     )

--- a/cmake/build_qt_with_openssl.cmake
+++ b/cmake/build_qt_with_openssl.cmake
@@ -21,6 +21,9 @@ endif()
 if(NOT QT_PLATFORM)
   message(FATAL_ERROR "QT_PLATFORM has not been set !")
 endif()
+if(NOT QT_VERSION)
+  message(FATAL_ERROR "QT_VERSION has not been set !")
+endif()
 if(NOT BITS MATCHES "^(32|64)$")
   message(FATAL_ERROR "BITS incorrectly set to [${BITS}].
 Hint: '32' or '64' value is expected.")
@@ -30,27 +33,28 @@ if(NOT EXISTS "${JOM_EXECUTABLE}")
 endif()
 message(STATUS "JOM_EXECUTABLE:${JOM_EXECUTABLE}")
 
-# Set compiler name based on Qt platform
-if(QT_PLATFORM STREQUAL "win32-msvc2013")
+# Set compiler name
+if(QT_PLATFORM STREQUAL "win32-msvc2017")
+  set(_compiler_name "vs2017")
+elseif(QT_PLATFORM STREQUAL "win32-msvc2015")
+  set(_compiler_name "vs2015")
+elseif(QT_PLATFORM STREQUAL "win32-msvc2013")
   set(_compiler_name "vs2013")
-elseif(QT_PLATFORM STREQUAL "win32-msvc2012")
-  set(_compiler_name "vs2012")
-elseif(QT_PLATFORM STREQUAL "win32-msvc2010")
-  set(_compiler_name "vs2010")
-elseif(QT_PLATFORM STREQUAL "win32-msvc2008")
-  set(_compiler_name "vs2008")
 else()
-  message(FATAL_ERROR "Specified QT_PLATFORM:${QT_PLATFORM} is not supported !")
+  message(FATAL_ERROR "Unknown qtPlatform: [${QT_PLATFORM}]")
 endif()
 
-# Get OpenSSL binaries download URL and MD5
-qeb_get_openssl_binaries_download_url(${BITS} ${QT_PLATFORM} "1.0.1h" OPENSSL_URL OPENSSL_MD5)
 
-set(QT_URL "http://packages.kitware.com/download/bitstream/8940/qt-everywhere-opensource-src-4.8.7.zip")
-set(QT_MD5 "0d3427d71aa0e8aec87288d7329e26cb")
+# Get OpenSSL binaries download URL and MD5
+qeb_get_openssl_binaries_download_url(${BITS} ${QT_PLATFORM} "1.0.2k" OPENSSL_URL OPENSSL_MD5)
+
+set(QT_URL "http://download.qt.io/official_releases/qt/${QT_MAJOR_VERSION}.${QT_MINOR_VERSION}/${QT_VERSION}/single/qt-everywhere-src-${QT_VERSION}.zip")
+set(QT_MD5 "db6a623759cdf9399bac95802742e40b")
+set(_version_string ${QT_VERSION})
+
 string(TOLOWER ${CMAKE_BUILD_TYPE} qt_build_type)
 string(SUBSTRING ${qt_build_type} 0 3 _short_build_type)
-set(QT_BUILD_DIR "${DEST_DIR}/qt-4.8.7-${BITS}-${_compiler_name}-${_short_build_type}")
+set(QT_BUILD_DIR "${DEST_DIR}/qt-${_version_string}-${BITS}-${_compiler_name}-${_short_build_type}")
 
 # Set OpenSSL variables
 get_filename_component(_archive_name ${OPENSSL_URL} NAME)
@@ -176,7 +180,7 @@ execute_process(
     -DOPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR}
     -DOPENSSL_LIBRARY_DIR=${OPENSSL_LIBRARY_DIR}
     -DQT_BUILD_DIR=${QT_BUILD_DIR}
-    -P ${CMAKE_CURRENT_LIST_DIR}/QEBQt4ExternalProjectCommand.cmake
+    -P ${CMAKE_CURRENT_LIST_DIR}/QEBQt5ExternalProjectCommand.cmake
   RESULT_VARIABLE result_var
   )
 if(NOT result_var EQUAL 0)
@@ -190,7 +194,7 @@ execute_process(
     ${common_options}
     -DQT_BUILD_DIR=${QT_BUILD_DIR}
     -DJOM_EXECUTABLE=${JOM_EXECUTABLE}
-    -P ${CMAKE_CURRENT_LIST_DIR}/QEBQt4ExternalProjectCommand.cmake
+    -P ${CMAKE_CURRENT_LIST_DIR}/QEBQt5ExternalProjectCommand.cmake
   RESULT_VARIABLE result_var
   )
 if(NOT result_var EQUAL 0)

--- a/windows_build_qt.ps1
+++ b/windows_build_qt.ps1
@@ -1,3 +1,12 @@
+# Qt version (major.minor.revision)
+$qtVersion = "5.10.0"
+
+# Building Tools
+$pythonVersion = "2.7.15" # if python not in path // if python in path is less than 2.7.5 or Python3
+$strawberryPerlVersion = "5.26.2.1" # if perl not in path
+$jomVersion = "1.1.2"
+$cmakeVersion = "3.11.4"
+
 # Sanity checks
 if(!$destDir){
   throw "'destDir' variable not set."
@@ -12,7 +21,7 @@ if(!($bits -match "^(32|64)$")){
   throw "'bits' variable incorrectly set to [$bits]. Hint: '32' or '64' value is expected."
 }
 
-$qtBuildScriptVersion = '6f59ca17b3bcc6b56fa636522dab6a862be0c856'
+$OSArchitecture = (Get-WmiObject Win32_OperatingSystem).OSArchitecture
 
 if (![System.IO.Directory]::Exists($destDir)) {[System.IO.Directory]::CreateDirectory($destDir)}
 
@@ -24,7 +33,7 @@ param (
   If (Test-Path $file) {
     Remove-Item $file
   }
-
+  
   $securityProtocolSettingsOriginal = [System.Net.ServicePointManager]::SecurityProtocol
 
   try {
@@ -40,7 +49,7 @@ param (
   Write-Host "Download $url"
   $downloader = new-object System.Net.WebClient
   $downloader.DownloadFile($url, $file)
-
+  
   [System.Net.ServicePointManager]::SecurityProtocol = $securityProtocolSettingsOriginal
 }
 
@@ -54,22 +63,107 @@ param (
   }
 }
 
+function IsPythonNeeded {
+    Param
+    (
+        [Parameter( Mandatory = $True )]
+        [string]
+        $Executable,
+
+        [string]
+        $MinimumVersion = ""
+    )
+    # Initial condition
+    $needpython = $False
+
+    if ((Get-Command -Name $Executable -ErrorAction SilentlyContinue) -eq $null) 
+    { 
+      Write-host "Unable to find $( $Executable ) in your PATH."
+      $needpython = $True
+    }
+    else
+    { # check python version
+      $version_output = & python -V 2>&1 # Wanting to get this part of output: "Python 2.7.15"
+      $CurrentVersionTable = [version]$version_output.ToString().split(" ")[1]
+      If( $CurrentVersionTable -lt [version]$MinimumVersion -Or $CurrentVersionTable -ge [version]"3.0.0" )
+        {
+        # Python 3 is not supported by Chromium
+        # Python 2 version >=2.7.5 is required to build Qt WebEngine
+        Write-host "$( $Executable ) version $( $CurrentVersion ) must be greater than $( $RequiredVersion ) and less than 3.0.0"
+        $needpython = $True
+        }
+    }
+    return $needpython
+}
+
 # download 7zip
 Write-Host "Download 7Zip commandline tool"
 $7zaExe = Join-Path $destDir '7za.exe'
 Download-File 'https://github.com/chocolatey/chocolatey/blob/master/src/tools/7za.exe?raw=true' "$7zaExe"
 
+# Check for and Install(if necessary) the additional tools needed to build
+$needpython = IsPythonNeeded -Executable python -MinimumVersion "2.7.5"
+if( $needpython ){
+  Write-Host "Download Python $pythonVersion"
+    if($OSArchitecture -match "64-bit"){
+    $pythonBaseName = "python-$pythonVersion.amd64"
+    }
+    else{
+    $pythonBaseName = "python-$pythonVersion"
+    }
+    $pythonArchiveName = "$pythonBaseName.msi"
+    $pythonInstallDir = Join-Path $destDir $pythonBaseName
+    $pythonArchiveUrl = "https://www.python.org/ftp/python/$pythonVersion/$pythonArchiveName"
+    $pythonArchiveFile = Join-Path $destDir $pythonArchiveName
+    Download-File $pythonArchiveUrl $pythonArchiveFile
+
+    # Install python with .MSI file
+    if (![System.IO.Directory]::Exists($pythonInstallDir)) {
+      Write-Host "Installing Python $pythonVersion"
+      Start-Process -FilePath "msiexec.exe" -ArgumentList "/i $pythonArchiveFile TARGETDIR=$pythonInstallDir /qn" -Wait -Passthru
+    }
+    $python = $pythonInstallDir
+    $env:Path = "$python;$env:Path"
+}
+
+if ((Get-Command "perl.exe" -ErrorAction SilentlyContinue) -eq $null) 
+{ 
+  Write-Host "Unable to find perl.exe in your PATH"
+  # download Strawberry Perl
+  Write-Host "Download Strawberry Perl portable tool"
+  if($OSArchitecture -match "64-bit"){
+    $perlBaseName = "strawberry-perl-$strawberryPerlVersion-64bit-portable"
+  }
+  else{
+    $perlBaseName = "strawberry-perl-$strawberryPerlVersion-32bit-portable"
+  }
+  $perlArchiveName = $perlBaseName + '.zip'
+  $perlInstallDir = Join-Path $destDir $perlBaseName
+  $perlArchiveUrl = "http://strawberryperl.com/download/$strawberryPerlVersion/$perlArchiveName"
+  $perlArchiveFile = Join-Path $destDir $perlArchiveName
+  Download-File $perlArchiveUrl $perlArchiveFile
+
+  # extract Strawberry Perl package
+  if (![System.IO.Directory]::Exists($perlInstallDir)) {
+    Write-Host "Extracting $perlArchiveFile to $perlInstallDir..."
+    Start-Process "$7zaExe" -ArgumentList "x -o`"$perlInstallDir`" -y `"$perlArchiveFile`"" -Wait
+  }
+  $perl = Join-Path $perlInstallDir 'perl/bin'
+  $perl1 = Join-Path $perlInstallDir 'perl/site/bin'
+  $perl2 = Join-Path $perlInstallDir 'c/bin'
+  $env:Path = "$perl;$perl1;$perl2;$env:Path"
+}
+
 # download jom
 Write-Host "Download jom commandline tool"
-$jomBaseName = 'jom_1_1_0'
-$jomArchiveName = $jomBaseName + '.zip'
+$jomBaseName = "jom_" + $jomVersion.replace(".","_")
+$jomArchiveName = "$jomBaseName.zip"
 $jomInstallDir = Join-Path $destDir $jomBaseName
-$jomArchiveUrl = 'http://download.qt.io/official_releases/jom/' + $jomArchiveName
+$jomArchiveUrl = "http://download.qt.io/official_releases/jom/$jomArchiveName"
 $jomArchiveFile = Join-Path $destDir $jomArchiveName
 Download-File $jomArchiveUrl $jomArchiveFile
-
 # if first attempt failed, try again from a different server
-$jomArchiveUrl = 'http://master.qt.io/official_releases/jom/' + $jomArchiveName
+$jomArchiveUrl = "http://master.qt.io/official_releases/jom/$jomArchiveName"
 Download-File $jomArchiveUrl $jomArchiveFile
 
 # extract jom package
@@ -81,10 +175,17 @@ $jom = Join-Path $jomInstallDir 'jom.exe'
 
 # download CMake
 Write-Host "Download CMake commandline tool"
-$cmakeBaseName = 'cmake-2.8.12.1-win32-x86'
-$cmakeArchiveName = $cmakeBaseName + '.zip'
+$cmakeVersionTable = [version]$cmakeVersion
+if($OSArchitecture -match "64-bit"){
+  $cmakeBaseName = "cmake-$cmakeVersion-win64-x64"
+}
+else{
+  $cmakeBaseName = "cmake-$cmakeVersion-win32-x86"
+}
+$cmakeArchiveName = "$cmakeBaseName.zip"
 $cmakeInstallDir = Join-Path $destDir $cmakeBaseName
-$cmakeArchiveUrl = 'http://www.cmake.org/files/v2.8/' + $cmakeArchiveName
+$cmakeMajorMinor = $cmakeVersion.substring(0, $cmakeVersion.LastIndexOf("."))
+$cmakeArchiveUrl = "http://www.cmake.org/files/v$cmakeMajorMinor/$cmakeArchiveName"
 $cmakeArchiveFile = Join-Path $destDir $cmakeArchiveName
 Download-File $cmakeArchiveUrl $cmakeArchiveFile
 
@@ -93,35 +194,44 @@ if (![System.IO.Directory]::Exists($cmakeInstallDir)) {
   Write-Host "Extracting $cmakeArchiveFile to $destDir..."
   Start-Process "$7zaExe" -ArgumentList "x -o`"$destDir`" -y `"$cmakeArchiveFile`"" -Wait
 }
-$cmake = Join-Path $cmakeInstallDir 'bin\cmake.exe'
+$cmake = Join-Path $cmakeInstallDir 'bin/cmake.exe'
 
 # download cross-platform build script
 $qtBuildScriptName = 'build_qt_with_openssl.cmake'
 $qtBuildScriptFile = Join-Path $destDir $qtBuildScriptName
-$url = ('https://raw.githubusercontent.com/jcfr/qt-easy-build/' + $qtBuildScriptVersion + '/cmake/' + $qtBuildScriptName)
+$url = ("https://raw.githubusercontent.com/jcfr/qt-easy-build/$qtVersion/cmake/$qtBuildScriptName")
+
 Always-Download-File $url $qtBuildScriptFile
 
 # download cross-platform helper script(s)
 $scriptName = 'QEBGetOpenSSLBinariesDownloadURL.cmake'
 $scriptFile = Join-Path $destDir $scriptName
-$url = ('https://raw.githubusercontent.com/jcfr/qt-easy-build/' + $qtBuildScriptVersion + '/cmake/' + $scriptName)
+$url = ("https://raw.githubusercontent.com/jcfr/qt-easy-build/$qtVersion/cmake/$scriptName")
 Always-Download-File $url $scriptFile
 
 # download cross-platform helper script(s)
-$scriptName = 'QEBQt4ExternalProjectCommand.cmake'
+$scriptName = 'QEBQt5ExternalProjectCommand.cmake'
 $scriptFile = Join-Path $destDir $scriptName
-$url = ('https://raw.githubusercontent.com/jcfr/qt-easy-build/' + $qtBuildScriptVersion + '/cmake/' + $scriptName)
+$url = ("https://raw.githubusercontent.com/jcfr/qt-easy-build/$qtVersion/cmake/$scriptName")
 Always-Download-File $url $scriptFile
 
 pushd $destDir
 
+$qtMajorVersion = $qtVersion.split(".")[0]
+$qtMinorVersion = $qtVersion.split(".")[1]
 Start-Process "$cmake" -ArgumentList `
   "-DCMAKE_BUILD_TYPE:STRING=$buildType",`
   "-DDEST_DIR:PATH=$destDir",`
   "-DQT_PLATFORM:STRING=$qtPlatform",`
+  "-DQT_VERSION:STRING=$qtVersion",`
+  "-DQT_MAJOR_VERSION:STRING=$qtMajorVersion",`
+  "-DQT_MINOR_VERSION:STRING=$qtMinorVersion",`
   "-DBITS:STRING=$bits",`
   "-DJOM_EXECUTABLE:FILEPATH=$jom",`
   "-P", "$qtBuildScriptFile"`
   -NoNewWindow -PassThru -Wait
+
+Write-Host "Uninstalling temporary Python27"
+Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $pythonArchiveFile /qn" -Wait -Passthru
 
 popd


### PR DESCRIPTION
This is updated work that supersedes PR #28 to match the new branch structure in this repo.

I've made sure to configure Qt like the macOS and Linux builds.  Please confirm that it is correct. URL links have already been changed to point to the location it would be in your repo.

I've tested a Qt 5.10.0 MSVC2015 build which succeeded, though when using it during the slicer configuration process I noticed it was missing Qt5Qml and Qt5Quick directories.  Not sure what the issue is there. If you can set up auto building for this that would be great.

Also the OpenSSL binaries are for version 1.0.2k which I compiled and uploaded to the kitware midas server back at the time of my original PR.  Note this is a different from 1.0.2n which is used in the macOS and Linux builds.  It is probably best for you to build and upload those scripts to the correct location in the kitware midas server if you want to use the same OpenSSL versions.

This adds the Windows platform updates for #15.
xref #44 