### PR TITLE
Qt version 5.10.1 download

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -7,7 +7,7 @@ set -o pipefail
 #
 
 # Qt version (major.minor.revision)
-QT_VERSION=5.10.0
+QT_VERSION=5.11.1
 
 # OpenSSL version
 OPENSSL_VERSION=1.0.2n
@@ -15,7 +15,7 @@ OPENSSL_MIDAS_PACKAGES_ITEM=10337
 
 # MD5 checksums
 OPENSSL_MD5="13bdc1b1d1ff39b6fd42a255e74676a4"
-QT_MD5="c5e275ab0ed7ee61d0f4b82cd471770d"
+QT_MD5="c6f0854d7de7bde80cfd8cc85bb7152b"
 
 QT_SRC_ARCHIVE_EXT="tar.xz"
 

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -7,7 +7,7 @@ set -o pipefail
 #
 
 # Qt version (major.minor.revision)
-QT_VERSION=5.11.1
+QT_VERSION=5.10.1
 
 # OpenSSL version
 OPENSSL_VERSION=1.0.2n
@@ -15,7 +15,7 @@ OPENSSL_MIDAS_PACKAGES_ITEM=10337
 
 # MD5 checksums
 OPENSSL_MD5="13bdc1b1d1ff39b6fd42a255e74676a4"
-QT_MD5="c6f0854d7de7bde80cfd8cc85bb7152b"
+QT_MD5="7e167b9617e7bd64012daaacb85477af"
 
 QT_SRC_ARCHIVE_EXT="tar.xz"
 


### PR DESCRIPTION
Configured script to download Qt version 5.10.1. Errors were found compiling 5.10.0 on MacOS 10.12 and 10.13: https://bugreports.qt.io/browse/QTBUG-65075
Qt version 5.11.1 is available at this time, but also had errors compiling.