### PR TITLE
Update building Qt on macOS to 5.12.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ os:
   - linux
   - osx
 
+# See https://docs.travis-ci.com/user/reference/xenial/
+dist: xenial
 # See https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
-osx_image: xcode7.3 # 10.11
+osx_image: xcode9.2 # 10.12 w/ macosx10.13 SDK https://doc.qt.io/qt-5.12/supported-platforms.html
 
 language: cpp
 
@@ -17,6 +19,45 @@ addons:
   apt:
     packages:
      - cmake
+     - gperf
+     # XCB
+     - libfontconfig1-dev # is already the newest version (2.11.94-0ubuntu1.1).
+     - libfreetype6-dev # is already the newest version (2.6.1-0.1ubuntu2.3).
+     - libx11-dev # is already the newest version (2:1.6.3-1ubuntu2.1).
+     - libxext-dev # is already the newest version (2:1.3.3-1).
+     - libxfixes-dev
+     - libxi-dev
+     - libxrender-dev # is already the newest version (1:0.9.9-0ubuntu1).
+     - libxcb1-dev # is already the newest version (1.11.1-1ubuntu1).
+     - libx11-xcb-dev
+     - libxcb-glx0-dev
+     - libxkbcommon-x11-dev
+
+    #  - libxcb-keysyms1-dev
+    #  - libxcb-image0-dev
+    #  - libxcb-shm0-dev
+    #  - libxcb-icccm4-dev
+    #  - libxcb-sync0-dev
+    #  - libxcb-xfixes0-dev
+    #  - libxcb-shape0-dev
+    #  - libxcb-randr0-dev
+    #  - libxcb-render-util0-dev
+
+     - libgl1-mesa-dev
+     # Qt WebEngine Required System Libraries
+     - libdbus-1-dev
+     - libnss3-dev
+       # Required libraries for xcb
+     - libdrm-dev
+     - libxcomposite-dev
+     - libxcursor-dev
+     - libxi-dev
+     - libxrandr-dev
+     - libxss-dev # is already the newest version (1:1.2.2-1).
+     - libxtst-dev
+     # Others
+     - khronos-api
+     - libcap-dev
 
 script:
  - ./Testing/travisCITest.sh

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -7,7 +7,7 @@ set -o pipefail
 #
 
 # Qt version (major.minor.revision)
-QT_VERSION=5.11.2
+QT_VERSION=5.12.4
 
 # OpenSSL version
 OPENSSL_VERSION=1.0.2p
@@ -15,7 +15,7 @@ OPENSSL_VERSION=1.0.2p
 
 # Checksums
 OPENSSL_SHA256="50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00"
-QT_MD5="152a8ade9c11fe33ff5bc95310a1bb64"
+QT_MD5="dda95b0239d13c5276834177af3a8588"
 
 QT_SRC_ARCHIVE_EXT="tar.xz"
 
@@ -79,7 +79,7 @@ then
   cat << EOF
 Options (macOS):
   -a             Set OSX architectures. (expected values: x86_64 or i386) [default: x86_64]
-  -d             OSX deployment target. [default: 10.10]
+  -d             OSX deployment target. [default: 10.12]
   -s             OSX sysroot. [default: macosx10.12]
 
 EOF
@@ -182,7 +182,7 @@ then
   # MacOS
   if [[ -z $osx_deployment_target ]]
   then
-    osx_deployment_target=10.10
+    osx_deployment_target=10.12
   fi
   if [[ -z $osx_sysroot ]]
   then

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -10,11 +10,10 @@ set -o pipefail
 QT_VERSION=5.12.4
 
 # OpenSSL version
-OPENSSL_VERSION=1.0.2p
-#OPENSSL_MIDAS_PACKAGES_ITEM=10337
+OPENSSL_VERSION=1.1.1c
 
 # Checksums
-OPENSSL_SHA256="50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00"
+OPENSSL_SHA256="f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"
 QT_MD5="dda95b0239d13c5276834177af3a8588"
 
 QT_SRC_ARCHIVE_EXT="tar.xz"
@@ -137,7 +136,6 @@ done
 command_not_found_install_hint="\n=> Consider installing the program using a package manager (apt-get, yum, homebrew, ...)"
 
 openssl_archive=openssl-$OPENSSL_VERSION.tar.gz
-#openssl_download_url=https://packages.kitware.com/download/item/$OPENSSL_MIDAS_PACKAGES_ITEM/$openssl_archive
 openssl_download_url=https://www.openssl.org/source/$openssl_archive
 
 qt_archive=qt-everywhere-src-$QT_VERSION.${QT_SRC_ARCHIVE_EXT}

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -79,7 +79,7 @@ then
 Options (macOS):
   -a             Set OSX architectures. (expected values: x86_64 or i386) [default: x86_64]
   -d             OSX deployment target. [default: 10.12]
-  -s             OSX sysroot. [default: macosx10.12]
+  -s             OSX sysroot. [default: macosx10.13]
 
 EOF
 fi
@@ -184,7 +184,7 @@ then
   fi
   if [[ -z $osx_sysroot ]]
   then
-    osx_sysroot=macosx10.12
+    osx_sysroot=macosx10.13
   fi
   if [[ -z $osx_architecture ]]
   then

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -357,6 +357,12 @@ cwd=$(pwd)
 mkdir -p $install_dir
 qt_install_dir_options="-prefix $install_dir"
 
+no_rpath_option=
+if [ "$(uname)" == "Darwin" ]
+then
+  no_rpath_option="-no-rpath"
+fi
+
 if [[ ! -d $src_dir ]]
 then
   tar --no-same-owner -xf $deps_dir/$qt_archive
@@ -368,7 +374,7 @@ cd $src_dir
   -c++std c++14 \
   -nomake examples \
   -nomake tests \
-  -no-rpath \
+  $no_rpath_option \
   -silent \
   -openssl -I $deps_dir/openssl-$OPENSSL_VERSION/include           \
   ${qt_macos_options}                                         \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Linux and macOS
 1. Open a terminal and copy the text below:
 
 ```
-curl -s https://raw.githubusercontent.com/jcfr/qt-easy-build/5.11.2/Build-qt.sh -o Build-qt.sh && chmod u+x Build-qt.sh
+curl -s https://raw.githubusercontent.com/jcfr/qt-easy-build/5.12.4/Build-qt.sh -o Build-qt.sh && chmod u+x Build-qt.sh
 ./Build-qt.sh -j 4
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Windows
 
 ### Notes ###
 
+* the minimum glibc version [supported by QtWebEngine is 2.17](https://github.com/qt/qtwebengine/commit/6d9fe6ba35024efc8e0a26435b51e25aa3ea7f09#diff-fb760d5130a8d1bf9c6f4be03ebcdc20). This excludes building QtWebEngine on less than CentOS 7, for example (local glibc version may be checked with `ldd --version`).
+
 * `buildType` can be set to either 'Release' or 'Debug'
 
 * `bits` can be set to either '32' or '64'

--- a/Testing/circleCITest.sh
+++ b/Testing/circleCITest.sh
@@ -14,5 +14,5 @@ docker run \
     -v ${root_dir}/qt-easy-build-build:/usr/src/qt-easy-build-build \
   fbudin69500/qt-easy-build-test \
     /usr/src/qt-easy-build/Testing/Docker/test.sh \
-      -j 4 -c -q "5.10.0" \
+      -j 4 -c -q "5.12.4" \
       -t "module-qtbase module-qtbase-install_subtargets"

--- a/Testing/travisCITest.sh
+++ b/Testing/travisCITest.sh
@@ -14,9 +14,9 @@ then
   -c \
   -j 4 \
   -y \
-  -s macosx10.11 \
+  -s macosx10.13 \
   -a x86_64 \
-  -d 10.9 \
+  -d 10.12 \
   -t "module-qtbase module-qtbase-install_subtargets"
 else
   $script_dir/../Build-qt.sh \

--- a/Testing/travisCITest.sh
+++ b/Testing/travisCITest.sh
@@ -31,7 +31,7 @@ die() {
   exit 1;
 }
 
-expected_qt_version="5.10.0"
+expected_qt_version="5.12.4"
 
 ./qt-everywhere-build-$expected_qt_version/bin/qmake --version | grep "Using Qt version $expected_qt_version" || die "Could not run Qt $expected_qt_version"
 


### PR DESCRIPTION
This branch is based on [`5.11.2`](https://github.com/jcfr/qt-easy-build/tree/5.11.2), but should be retargeted to a new branch titled `5.12.4`.

To support building Qt 5.12.4 QWebEngine on macOS see [platform notes](https://doc.qt.io/qt-5.12/qtwebengine-platform-notes.html#macos):
- macOS 10.12 or later.
- Xcode 8.3.3 or later
- macOS 10.12 SDK or later

From ToDo list in:
https://discourse.slicer.org/t/build-failure-windows/7322/37