### PR TITLE
Update building Qt on macOS to 5.12.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ os:
   - linux
   - osx
 
+# See https://docs.travis-ci.com/user/reference/xenial/
+dist: xenial
 # See https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
-osx_image: xcode7.3 # 10.11
+osx_image: xcode9.2 # 10.12 w/ macosx10.13 SDK https://doc.qt.io/qt-5.12/supported-platforms.html
 
 language: cpp
 
@@ -17,6 +19,25 @@ addons:
   apt:
     packages:
      - cmake
+     # https://doc-snapshots.qt.io/qt5-5.12/linux.html
+     - libgl1-mesa-dev
+     # https://doc.qt.io/qt-5.12/qtwebengine-platform-notes.html#all-platforms
+     - gperf
+     # https://doc.qt.io/qt-5.12/qtwebengine-platform-notes.html#linux
+     - libdbus-1-dev
+     - libnss3-dev
+     - libfontconfig1-dev # is already the newest version (2.11.94-0ubuntu1.1).
+     # Qt WebEngine for xcb
+     - libdrm-dev
+     - libxcomposite-dev
+     - libxcursor-dev
+     - libxi-dev
+     - libxrandr-dev
+     - libxss-dev
+     - libxtst-dev
+     # Qt WebEngine other development packages
+     - libegl1-mesa-dev
+     - libcap-dev
 
 script:
  - ./Testing/travisCITest.sh

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -10,11 +10,10 @@ set -o pipefail
 QT_VERSION=5.12.7
 
 # OpenSSL version
-OPENSSL_VERSION=1.0.2p
-#OPENSSL_MIDAS_PACKAGES_ITEM=10337
+OPENSSL_VERSION=1.1.1d
 
 # Checksums
-OPENSSL_SHA256="50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00"
+OPENSSL_SHA256="1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2"
 QT_MD5="ce2c5661c028b9de6183245982d7c120"
 
 QT_SRC_ARCHIVE_EXT="tar.xz"
@@ -137,7 +136,6 @@ done
 command_not_found_install_hint="\n=> Consider installing the program using a package manager (apt-get, yum, homebrew, ...)"
 
 openssl_archive=openssl-$OPENSSL_VERSION.tar.gz
-#openssl_download_url=https://packages.kitware.com/download/item/$OPENSSL_MIDAS_PACKAGES_ITEM/$openssl_archive
 openssl_download_url=https://www.openssl.org/source/$openssl_archive
 
 qt_archive=qt-everywhere-src-$QT_VERSION.${QT_SRC_ARCHIVE_EXT}

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -283,7 +283,7 @@ then
                 -DCMAKE_OSX_SYSROOT=$osx_sysroot
                 -DCMAKE_OSX_DEPLOYMENT_TARGET=$osx_deployment_target"
   export KERNEL_BITS=64
-  qt_macos_options="-sdk $osx_sysroot"
+  qt_macos_options="-sdk $osx_sysroot -webengine-spellchecker -webengine-native-spellchecker"
 
   sha256_openssl=`shasum -a 256 ./$openssl_archive | awk '{ print $1 }'`
   md5_qt=`md5 ./$qt_archive | awk '{ print $4 }'`
@@ -355,27 +355,26 @@ cwd=$(pwd)
 mkdir -p $install_dir
 qt_install_dir_options="-prefix $install_dir"
 
-no_rpath_option=
-if [ "$(uname)" == "Darwin" ]
-then
-  no_rpath_option="-no-rpath"
-fi
-
 if [[ ! -d $src_dir ]]
 then
   tar --no-same-owner -xf $deps_dir/$qt_archive
 fi
 cd $src_dir
 
+# Options used to mimic the homebrew packaging of Qt5
+#qt_homebrew_package_options="-system-zlib -qt-libpng -qt-libjpeg -qt-freetype -qt-pcre -dbus-runtime -proprietary-codecs"
+qt_build_mode="-silent"
+qt_build_mode="-verbose"
+
+# NOTE:  C++14 is needed to support QtWebEngine from chromium
 ./configure $qt_install_dir_options                           \
   -release -opensource -confirm-license \
   -c++std c++14 \
   -nomake examples \
   -nomake tests \
-  $no_rpath_option \
+  -no-rpath \
   -silent \
   -openssl -I $deps_dir/openssl-$OPENSSL_VERSION/include           \
-  -no-webengine-spellchecker  \
   ${qt_macos_options}                                         \
   -L $deps_dir/openssl-$OPENSSL_VERSION
 

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -79,7 +79,7 @@ then
 Options (macOS):
   -a             Set OSX architectures. (expected values: x86_64 or i386) [default: x86_64]
   -d             OSX deployment target. [default: 10.12]
-  -s             OSX sysroot. [default: macosx10.12]
+  -s             OSX sysroot. [default: macosx10.13]
 
 EOF
 fi
@@ -184,7 +184,7 @@ then
   fi
   if [[ -z $osx_sysroot ]]
   then
-    osx_sysroot=macosx10.12
+    osx_sysroot=macosx10.13
   fi
   if [[ -z $osx_architecture ]]
   then

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -357,6 +357,12 @@ cwd=$(pwd)
 mkdir -p $install_dir
 qt_install_dir_options="-prefix $install_dir"
 
+no_rpath_option=
+if [ "$(uname)" == "Darwin" ]
+then
+  no_rpath_option="-no-rpath"
+fi
+
 if [[ ! -d $src_dir ]]
 then
   tar --no-same-owner -xf $deps_dir/$qt_archive
@@ -368,7 +374,7 @@ cd $src_dir
   -c++std c++14 \
   -nomake examples \
   -nomake tests \
-  -no-rpath \
+  $no_rpath_option \
   -silent \
   -openssl -I $deps_dir/openssl-$OPENSSL_VERSION/include           \
   ${qt_macos_options}                                         \

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -7,7 +7,7 @@ set -o pipefail
 #
 
 # Qt version (major.minor.revision)
-QT_VERSION=5.11.2
+QT_VERSION=5.12.7
 
 # OpenSSL version
 OPENSSL_VERSION=1.0.2p
@@ -15,7 +15,7 @@ OPENSSL_VERSION=1.0.2p
 
 # Checksums
 OPENSSL_SHA256="50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00"
-QT_MD5="152a8ade9c11fe33ff5bc95310a1bb64"
+QT_MD5="ce2c5661c028b9de6183245982d7c120"
 
 QT_SRC_ARCHIVE_EXT="tar.xz"
 
@@ -79,7 +79,7 @@ then
   cat << EOF
 Options (macOS):
   -a             Set OSX architectures. (expected values: x86_64 or i386) [default: x86_64]
-  -d             OSX deployment target. [default: 10.10]
+  -d             OSX deployment target. [default: 10.12]
   -s             OSX sysroot. [default: macosx10.12]
 
 EOF
@@ -182,7 +182,7 @@ then
   # MacOS
   if [[ -z $osx_deployment_target ]]
   then
-    osx_deployment_target=10.10
+    osx_deployment_target=10.12
   fi
   if [[ -z $osx_sysroot ]]
   then

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -375,6 +375,7 @@ cd $src_dir
   $no_rpath_option \
   -silent \
   -openssl -I $deps_dir/openssl-$OPENSSL_VERSION/include           \
+  -no-webengine-spellchecker  \
   ${qt_macos_options}                                         \
   -L $deps_dir/openssl-$OPENSSL_VERSION
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Linux and macOS
 1. Open a terminal and copy the text below:
 
 ```
-curl -s https://raw.githubusercontent.com/jcfr/qt-easy-build/5.11.2/Build-qt.sh -o Build-qt.sh && chmod u+x Build-qt.sh
+curl -s https://raw.githubusercontent.com/jcfr/qt-easy-build/5.12.7/Build-qt.sh -o Build-qt.sh && chmod u+x Build-qt.sh
 ./Build-qt.sh -j 4
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Windows
 
 ### Notes ###
 
+* the minimum glibc version [supported by QtWebEngine is 2.17](https://github.com/qt/qtwebengine/commit/6d9fe6ba35024efc8e0a26435b51e25aa3ea7f09#diff-fb760d5130a8d1bf9c6f4be03ebcdc20). This excludes building QtWebEngine on less than CentOS 7, for example (local glibc version may be checked with `ldd --version`).
+
 * `buildType` can be set to either 'Release' or 'Debug'
 
 * `bits` can be set to either '32' or '64'

--- a/Testing/AzurePipelines.yml
+++ b/Testing/AzurePipelines.yml
@@ -1,0 +1,129 @@
+name: qt-easy-build
+trigger:
+  branches:
+    include:
+    - 5.12.*
+jobs:
+  - job: Linux
+    timeoutInMinutes: 0
+    cancelTimeoutInMinutes: 300
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
+      - script: |
+          sudo apt-get install libclang-dev -y
+        displayName: 'Install QDoc Requirements'
+      - script: |
+          # https://doc-snapshots.qt.io/qt5-5.12/linux.html
+          sudo apt-get install build-essential libgl1-mesa-dev -y
+        displayName: 'Install Qt Requirements for Development'
+      - script: |
+          # https://doc.qt.io/qt-5.12/qtwebengine-platform-notes.html#all-platforms
+          sudo apt-get install bison flex gperf -y
+          # https://doc.qt.io/qt-5.12/qtwebengine-platform-notes.html#linux
+          sudo apt-get install libdbus-1-dev libnss3-dev libfontconfig1-dev -y
+          # Qt WebEngine for xcb
+          sudo apt-get install libdrm-dev libxcomposite-dev libxcursor-dev libxi-dev libxrandr-dev libxss-dev libxtst-dev -y
+          # Qt WebEngine other development packages
+          sudo apt-get install libegl1-mesa-dev -y # suggested when build failed to find khronos development headers
+          sudo apt-get install libcap-dev -y
+        displayName: 'Install Qt WebEngine Requirements for Development'
+      - bash: |
+          set -e
+          set -o pipefail
+
+          c++ --version
+          cmake --version
+
+          script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+          pushd $script_dir
+
+          $(Build.SourcesDirectory)/Build-qt.sh \
+          -c \
+          -j 4 \
+          -y
+
+          die() {
+            echo "Error: $@" 1>&2
+            exit 1;
+          }
+
+          expected_qt_version="5.12.7"
+
+          ./qt-everywhere-build-$expected_qt_version/bin/qmake --version | grep "Using Qt version $expected_qt_version" || die "Could not run Qt $expected_qt_version"
+
+          popd
+
+  - job: macOS
+    timeoutInMinutes: 0
+    cancelTimeoutInMinutes: 300
+    strategy:
+        maxParallel: 4
+        matrix:
+          # https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md
+          # https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.13-Readme.md
+          XCode_10:
+            imageName: 'macos-10.14'
+            xcodeVersion: 10.2
+            sdk: 'macosx10.14'
+            deploymentTarget: '10.14'
+          XCode_9_4:
+            imageName: 'macos-10.14'
+            xcodeVersion: 9.4.1
+            sdk: 'macosx10.13'
+            deploymentTarget: '10.13'
+          XCode_9_3:
+            imageName: 'macos-10.13'
+            xcodeVersion: 9.3
+            sdk: 'macosx10.13'
+            deploymentTarget: '10.12'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - checkout: self
+        clean: true
+        fetchDepth: 5
+      - script: |
+          brew install llvm
+        displayName: 'Install QDoc Requirements'
+      - bash: |
+          set -e
+          set -o pipefail
+
+          xcode-select -p
+          sudo xcode-select -s /Applications/Xcode_$(xcodeVersion).app/Contents/Developer/
+          xcode-select -p
+          c++ --version
+          cmake --version
+
+          if [[ $(imageName) == 'macos-10.14' ]] && [[ $(xcodeVersion) == 9.4.1 ]]
+          then
+            sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+          fi
+
+          script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+          pushd $script_dir
+
+          $(Build.SourcesDirectory)/Build-qt.sh \
+          -c \
+          -j 4 \
+          -y \
+          -s $(sdk) \
+          -a x86_64 \
+          -d $(deploymentTarget)
+
+          die() {
+            echo "Error: $@" 1>&2
+            exit 1;
+          }
+
+          expected_qt_version="5.12.7"
+
+          ./qt-everywhere-build-$expected_qt_version/bin/qmake --version | grep "Using Qt version $expected_qt_version" || die "Could not run Qt $expected_qt_version"
+
+          popd

--- a/Testing/circleCITest.sh
+++ b/Testing/circleCITest.sh
@@ -14,5 +14,5 @@ docker run \
     -v ${root_dir}/qt-easy-build-build:/usr/src/qt-easy-build-build \
   fbudin69500/qt-easy-build-test \
     /usr/src/qt-easy-build/Testing/Docker/test.sh \
-      -j 4 -c -q "5.10.0" \
+      -j 4 -c -q "5.12.7" \
       -t "module-qtbase module-qtbase-install_subtargets"

--- a/Testing/travisCITest.sh
+++ b/Testing/travisCITest.sh
@@ -14,9 +14,9 @@ then
   -c \
   -j 4 \
   -y \
-  -s macosx10.11 \
+  -s macosx10.13 \
   -a x86_64 \
-  -d 10.9 \
+  -d 10.12 \
   -t "module-qtbase module-qtbase-install_subtargets"
 else
   $script_dir/../Build-qt.sh \

--- a/Testing/travisCITest.sh
+++ b/Testing/travisCITest.sh
@@ -31,7 +31,7 @@ die() {
   exit 1;
 }
 
-expected_qt_version="5.10.0"
+expected_qt_version="5.12.7"
 
 ./qt-everywhere-build-$expected_qt_version/bin/qmake --version | grep "Using Qt version $expected_qt_version" || die "Could not run Qt $expected_qt_version"
 


### PR DESCRIPTION
This branch is based on [`5.11.2`](https://github.com/jcfr/qt-easy-build/tree/5.11.2), but should be retargeted to a new branch titled `5.12.7`.

**NEW:** Azure Pipelines testing was added although TravisCI testing was updated as well. Azure Pipelines status badges for Linux and macOS builds can be seen on my fork's welcome branch page. https://github.com/jamesobutler/qt-easy-build/tree/welcome

Qt 5.12.7 supports the below configuration ([source](https://doc-snapshots.qt.io/qt5-5.12/supported-platforms.html))

| Platform | Architecture | Build Environment |
|-----------|-----------|--------|
|macOS 10.12, 10.13, 10.14| x86_64 and x86_64h | Xcode 10 (10.14 SDK), Xcode 9 (10.13 SDK)|


To support building Qt 5.12.7 QtWebEngine on macOS see [platform notes](https://doc.qt.io/qt-5.12/qtwebengine-platform-notes.html#macos). These are actually fulfilled if building Qt core as stated above.
- macOS 10.12 or later.
- Xcode 8.3.3 or later
- macOS 10.12 SDK or later

From ToDo list in:
https://discourse.slicer.org/t/build-failure-windows/7322/37