### PR TITLE
[5.15.1] Build Qt for linux with xinerama  disabled

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -291,6 +291,7 @@ else
   # Linux
   sha256_openssl=`sha256sum ./$openssl_archive | awk '{ print $1 }'`
   md5_qt=`md5sum ./$qt_archive | awk '{ print $1 }'`
+  qt_linux_options="-no-xinerama"
 fi
 if [ "$sha256_openssl" != "$OPENSSL_SHA256" ]
 then
@@ -376,6 +377,7 @@ qt_build_mode="-verbose"
   -silent \
   -openssl -I $deps_dir/openssl-$OPENSSL_VERSION/include           \
   ${qt_macos_options}                                         \
+  ${qt_linux_options}                                         \
   -L $deps_dir/openssl-$OPENSSL_VERSION
 
 if [[ -z $qt_targets ]]


### PR DESCRIPTION
See https://discourse.slicer.org/t/cant-start-latest-stable-on-ubuntu-20-04/14029/4?
and https://github.com/Slicer/Slicer/issues/5251