### PR TITLE
BUG: Revert no-xinerama due to build error

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -291,7 +291,6 @@ else
   # Linux
   sha256_openssl=`sha256sum ./$openssl_archive | awk '{ print $1 }'`
   md5_qt=`md5sum ./$qt_archive | awk '{ print $1 }'`
-  qt_linux_options="-no-xinerama"
 fi
 if [ "$sha256_openssl" != "$OPENSSL_SHA256" ]
 then
@@ -377,7 +376,6 @@ qt_build_mode="-verbose"
   -silent \
   -openssl -I $deps_dir/openssl-$OPENSSL_VERSION/include           \
   ${qt_macos_options}                                         \
-  ${qt_linux_options}                                         \
   -L $deps_dir/openssl-$OPENSSL_VERSION
 
 if [[ -z $qt_targets ]]

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -310,7 +310,7 @@ mkdir -p zlib-install
 mkdir -p zlib-build
 if [[ ! -d zlib ]]
 then
-  git clone git://github.com/commontk/zlib.git
+  git clone https://github.com/commontk/zlib.git
 fi
 cd zlib-build
 $cmake -DCMAKE_BUILD_TYPE:STRING=Release             \

--- a/Build-qt.txt
+++ b/Build-qt.txt
@@ -13,7 +13,7 @@ cwd=$(pwd)
 rm -rf zlib* && \
 mkdir zlib-install  && \
 mkdir zlib-build  && \
-git clone git://github.com/commontk/zlib.git  && \
+git clone https://github.com/commontk/zlib.git  && \
 cd zlib-build  && \
 "$cmake" -DCMAKE_BUILD_TYPE:STRING=Release \
        -DZLIB_MANGLE_PREFIX:STRING=slicer_zlib_ \
@@ -87,7 +87,7 @@ cwd=$(pwd)
 rm -rf zlib* && \
 mkdir zlib-install  && \
 mkdir zlib-build  && \
-git clone git://github.com/commontk/zlib.git  && \
+git clone https://github.com/commontk/zlib.git  && \
 cd zlib-build  && \
 "$cmake" -DCMAKE_BUILD_TYPE:STRING=Release \
        -DZLIB_MANGLE_PREFIX:STRING=slicer_zlib_ \


### PR DESCRIPTION
Reverts d9ae8b8 due to build error.

Also using this to test the azure automated build for the 5.15.x branch