### PR TITLE
ci: Update AzurePipelines job to use ubuntu-20.04 instead of ubuntu-18.04

### DIFF
--- a/Testing/AzurePipelines.yml
+++ b/Testing/AzurePipelines.yml
@@ -8,7 +8,7 @@ jobs:
     timeoutInMinutes: 0
     cancelTimeoutInMinutes: 300
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-20.04'
     steps:
       - checkout: self
         clean: true


### PR DESCRIPTION
This commit addresses the following warning:

> ##[warning]The ubuntu-18.04 environment is deprecated,
> consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04
> instead.
> For more details see https://github.com/actions/virtual-environments/issues/6002