### PR TITLE
Fix macos 13 build

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -370,10 +370,6 @@ then
 fi
 cd $src_dir
 
-# Options used to mimic the homebrew packaging of Qt5
-#qt_homebrew_package_options="-system-zlib -qt-libpng -qt-libjpeg -qt-freetype -qt-pcre -dbus-runtime -proprietary-codecs"
-qt_build_mode="-silent"
-qt_build_mode="-verbose"
 
 # NOTE:  C++14 is needed to support QtWebEngine from chromium
 ./configure $qt_install_dir_options                           \

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -2,6 +2,9 @@
 set -ex
 set -o pipefail
 
+script_dir=$(cd $(dirname $0) || exit 1; pwd)
+
+
 #
 # Configuration
 #
@@ -358,6 +361,12 @@ qt_install_dir_options="-prefix $install_dir"
 if [[ ! -d $src_dir ]]
 then
   tar --no-same-owner -xf $deps_dir/$qt_archive
+
+  # Apply patches
+  pushd $src_dir
+  git apply --ignore-whitespace $script_dir/patches/*.patch
+  popd
+
 fi
 cd $src_dir
 

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -348,6 +348,28 @@ then
 fi
 cd ..
 
+# Build Python 2.7: required to build QtWebEngine and QtPdf in Qt 5.15.x
+echo "Build Python 2.7"
+
+cwd=$(pwd)
+
+mkdir -p python-cmake-buildsystem-build
+if [[ ! -d python-cmake-buildsystem ]]
+then
+  git clone https://github.com/python-cmake-buildsystem/python-cmake-buildsystem.git
+fi
+cd python-cmake-buildsystem-build
+$cmake \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DCMAKE_INSTALL_PREFIX:PATH=$cwd/python-cmake-buildsystem-install \
+  -DPYTHON_VERSION:STRING=2.7.15 \
+  -DBUILD_LIBPYTHON_SHARED:BOOL=ON \
+  -DENABLE_SSL:BOOL=OFF \
+  ../python-cmake-buildsystem
+
+$cmake --build $cwd/python-cmake-buildsystem-build --config Release --target install -- -j$nbthreads
+cd ..
+
 popd
 
 # Build Qt
@@ -370,6 +392,7 @@ then
 fi
 cd $src_dir
 
+export PATH=$deps_dir/python-cmake-buildsystem-install/bin:$PATH
 
 # NOTE:  C++14 is needed to support QtWebEngine from chromium
 ./configure $qt_install_dir_options                           \

--- a/patches/0001-8467beddb-add-missing-macos-header-file-that-was-indirectly-included.patch
+++ b/patches/0001-8467beddb-add-missing-macos-header-file-that-was-indirectly-included.patch
@@ -1,0 +1,26 @@
+From 8467beddb7239cc213ae13900fa30e3d26df5e78 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98ystein=20Heskestad?= <oystein.heskestad@qt.io>
+Date: Wed, 27 Oct 2021 13:07:46 +0200
+Subject: [PATCH] Add missing macOS header file that was indirectly included
+ before
+
+Change-Id: I4d4c7d4f957fc36dea5e06eb6d661aeecf6385f1
+(cherry picked from commit dece6f5840463ae2ddf927d65eb1b3680e34a547)
+Reviewed-by: Volker Hilsheimer <volker.hilsheimer@qt.io>
+---
+ src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h b/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+index dd3ebca4a65..ee7ac5c0143 100644
+--- a/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
++++ b/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+@@ -43,6 +43,8 @@
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>
+ 
++#include <CoreGraphics/CGColorSpace.h>
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QIOSurfaceGraphicsBuffer : public QPlatformGraphicsBuffer

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,11 @@
+# Qt Patches
+
+Fixes and improvements to Qt that should first be contributed upstream. The [Qt Contribution Guidelines](https://wiki.qt.io/Qt_Contribution_Guidelines) is a great resource to guide you through the process.
+
+Each patch is documented by adding an entry below. Whenever possible, references to bugs.python.org https://bugreports.qt.io/, corresponding GitHub PRs and any related discussions on forums or mailing lists are also provided.
+
+Before being applied, patches are sorted alphabetically. This ensures that patch starting with 0001- is applied before the one starting with 0002-.
+
+## Patches
+
+* NA

--- a/patches/README.md
+++ b/patches/README.md
@@ -8,4 +8,4 @@ Before being applied, patches are sorted alphabetically. This ensures that patch
 
 ## Patches
 
-* NA
+* [0001-8467beddb-add-missing-macos-header-file-that-was-indirectly-included.patch][0001-8467beddb-add-missing-macos-header-file-that-was-indirectly-included.patch] adapted from [qt/qtbase@8467beddb](https://github.com/qt/qtbase/commit/8467beddb7239cc213ae13900fa30e3d26df5e78). The `qtbase/` sub-directory has been added to the patch.


### PR DESCRIPTION
* After updating `computron` macOS version from macOS 10.15 (Catalina) to macOS 13.0 (Ventura), python 2.7 originally available on macOS 10.15 now required to explicitly built.

* To support building Qt 5.15.2 on macOS 13.0, the patch corresponding to qt/qtbase@8467beddb (`Add missing macOS header file that was indirectly included before`) needs to be applied.