### PR TITLE
DOC: Update list of maintained Qt branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,11 @@ You will find here scripts allowing to very easily build Qt with OpenSSL support
 
 Scripts available for these Qt versions:
 
-* [5.15.2][5152]
+* [5.15.16][51516]
+* [5.15.8][5158]
 
-[5152]: https://github.com/jcfr/qt-easy-build/tree/5.15.2#readme
-
-| Qt Version   | Linux                                                   | macOS                                                   | Windows CI |
-|--------------|---------------------------------------------------------|---------------------------------------------------------|------------|
-| 5.15.2       | [![Build Status][5152_linux_i_azure]][5152_linux_azure] | [![Build Status][5152_macos_i_azure]][5152_macos_azure] | [![Build Status][5152_windows_i_azure]][5152_windows_azure]         |
-
-[5152_linux_azure]: https://dev.azure.com/jamesobutler/qt-easy-build/_build/latest?definitionId=1&branchName=5.15.2
-[5152_linux_i_azure]: https://dev.azure.com/jamesobutler/qt-easy-build/_apis/build/status/jamesobutler.qt-easy-build?branchName=5.15.2&jobName=Linux
-
-[5152_macos_azure]: https://dev.azure.com/jamesobutler/qt-easy-build/_build/latest?definitionId=1&branchName=5.15.2
-[5152_macos_i_azure]: https://dev.azure.com/jamesobutler/qt-easy-build/_apis/build/status/jamesobutler.qt-easy-build?branchName=5.15.2&jobName=macOS
-
-[5152_windows_azure]: https://dev.azure.com/jamesobutler/qt-easy-build/_build/latest?definitionId=1&branchName=5.15.2
-[5152_windows_i_azure]: https://dev.azure.com/jamesobutler/qt-easy-build/_apis/build/status/jamesobutler.qt-easy-build?branchName=5.15.2&jobName=Windows
+[51516]: https://github.com/jcfr/qt-easy-build/tree/5.15.16#readme
+[5158]: https://github.com/jcfr/qt-easy-build/tree/5.15.8#readme
 
 # Unmaintained Qt build scripts
 


### PR DESCRIPTION
@jcfr This updates the Welcome branch page with latest supported branches. This specifically includes the adding of the Qt [5.15.16](https://github.com/jcfr/qt-easy-build/tree/5.15.16) branch to the welcome page. 

I have just pushed this new branch with updates and patches to successfully build Qt. I was specifically testing building it on an M2 Pro Mac Mini with latest macOS and build tools. I added to that branch's readme information regarding building for the x86_64 architecture while on the Apple Silicon arm64 architecture. Please take a look and make changes as you see fit on this new branch.

Upon having Build-qt.sh download and with the [patch directory](https://github.com/jcfr/qt-easy-build/tree/5.15.16/patches) downloaded next to it, the following build execution completed on my M2 Pro Mac Mini in 2hr45min.
`./Build-qt.sh -a x86_64 -s macosx15.2 -d 13 -j 4`