### PR TITLE
BUG: Fix unable to build Python 2.7 with latest python-cmake-buildsystem

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -361,6 +361,8 @@ if [[ ! -d python-cmake-buildsystem ]]
 then
   git clone https://github.com/python-cmake-buildsystem/python-cmake-buildsystem.git
 fi
+# Checkout an older python-cmake-buildsystem commit that is compatible with Python 2.7
+(cd python-cmake-buildsystem; git checkout 39d95fd6f6bc78f4d7fa4217093281aa736517c9)
 cd python-cmake-buildsystem-build
 $cmake \
   -DCMAKE_BUILD_TYPE:STRING=Release \


### PR DESCRIPTION
This closes https://github.com/commontk/qt-easy-build/issues/76. cc: @pieper to try and test this out

python-cmake-buildsystem dropped support for Python 2 in https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/commit/639188900d8e5bb4167f26ea7e72ca266639c3ec.