### PR TITLE
[5.15.18] Fix detection of OpenGL Qt backend and OpenSSL linkage on macOS 

### DIFF
--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -339,6 +339,7 @@ then
   tar --no-same-owner -xf $openssl_archive
 fi
 cd openssl-$OPENSSL_VERSION/
+LDFLAGS="-Wl,-headerpad_max_install_names" \
 ./config zlib -I$cwd/zlib-install/include -L$cwd/zlib-install/lib shared
 make -j 1 build_libs
 # If MacOS, install openssl libraries

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -419,6 +419,7 @@ then
     0003-qtwebengine-clang16.patch
     patch-qtwebengine-patch-zlib.diff # Backport fix for https://bugreports.qt.io/browse/QTBUG-138486
     patch-qtwebengine-crc32c-arm64.diff
+    patch-qtwebengine-libpng.diff
   )
 
   if [ "$(uname)" == "Darwin" ]

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -412,7 +412,7 @@ then
       --depth 1 \
       --shallow-submodules \
       --filter=blob:none \
-      https://github.com/qt/qtwebengine.git -b v5.15.18-lts-lgpl qtwebengine
+      https://github.com/qt/qtwebengine.git -b v5.15.19-lts qtwebengine
     echo "Found $patch_count patches"
     git apply --ignore-whitespace $script_dir/patches/*.patch
   fi

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -397,10 +397,22 @@ then
   then
     echo "Cloning qtlocation so that patches can be applied with git"
     rm -r qtlocation
-    git clone --recurse-submodules https://github.com/qt/qtlocation.git -b v5.15.18-lts-lgpl qtlocation
+    git clone \
+      --recurse-submodules \
+      --single-branch \
+      --depth 1 \
+      --shallow-submodules \
+      --filter=blob:none \
+      https://github.com/qt/qtlocation.git -b v5.15.18-lts-lgpl qtlocation
     echo "Cloning qtwebengine so that patches can be applied with git"
     rm -r qtwebengine
-    git clone --recurse-submodules https://github.com/qt/qtwebengine.git -b v5.15.18-lts-lgpl qtwebengine
+    git clone \
+      --recurse-submodules \
+      --single-branch \
+      --depth 1 \
+      --shallow-submodules \
+      --filter=blob:none \
+      https://github.com/qt/qtwebengine.git -b v5.15.18-lts-lgpl qtwebengine
     echo "Found $patch_count patches"
     git apply --ignore-whitespace $script_dir/patches/*.patch
   fi

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -416,7 +416,7 @@ then
 
   qtwebengine_patches=(
     # 0002-qtwebengine-ninja1.12.patch
-    # 0003-qtwebengine-clang16.patch
+    0003-qtwebengine-clang16.patch
     patch-qtwebengine-patch-zlib.diff # Backport fix for https://bugreports.qt.io/browse/QTBUG-138486
     patch-qtwebengine-crc32c-arm64.diff
   )

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -445,7 +445,7 @@ then
 
     for patch_file in "${qtlocation_patches[@]}"; do
       echo "Applying $patch_file"
-      git apply --ignore-whitespace $script_dir/patches/${patch_file}
+      git apply --verbose --ignore-whitespace $script_dir/patches/${patch_file}
     done
   fi
 
@@ -466,7 +466,7 @@ then
 
     for patch_file in "${qtwebengine_patches[@]}"; do
       echo "Applying $patch_file"
-      git apply --ignore-whitespace $script_dir/patches/${patch_file}
+      git apply --verbose --ignore-whitespace $script_dir/patches/${patch_file}
     done
 
   fi
@@ -476,7 +476,7 @@ then
 
   for patch_file in "${patches[@]}"; do
       echo "Applying $patch_file"
-    git apply --ignore-whitespace $script_dir/patches/${patch_file}
+    git apply --verbose --ignore-whitespace $script_dir/patches/${patch_file}
   done
 
   popd

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -407,6 +407,13 @@ then
     patch-qtlocation-narrowing-const-reference.diff # https://trac.macports.org/ticket/73016
   )
 
+  if [ "$(uname)" == "Darwin" ]
+  then
+    qtlocation_patches+=(
+      patch-boost-clang16-cpp17-compat.diff
+    )
+  fi
+
   qtwebengine_patches=(
     # 0002-qtwebengine-ninja1.12.patch
     # 0003-qtwebengine-clang16.patch

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -390,11 +390,49 @@ if [[ ! -d $src_dir ]]
 then
   tar --no-same-owner -xf $deps_dir/$qt_archive
 
+  # Collect patches
+  # - Adapted in part from https://github.com/macports/macports-ports/tree/master/aqua/qt5/files
+  patches=(
+    0004-qtbase-tahoe-no-agl-framework.patch
+
+    # TODO: remove when updating to 5.15.19
+    CVE-2025-4211-qtbase-5.15.diff
+    CVE-2025-5455-qtbase-5.15.patch
+    CVE-2025-30348-qtbase-5.15.diff
+    CVE-2025-23050-qtconnectivity-5.15.diff
+  )
+  qtlocation_patches=(
+    0001-qtlocation-clang16.patch
+    patch-qtlocation-mbgl-unique_any.hpp.diff
+    patch-qtlocation-narrowing-const-reference.diff # https://trac.macports.org/ticket/73016
+  )
+
+  qtwebengine_patches=(
+    0002-qtwebengine-ninja1.12.patch
+    0003-qtwebengine-clang16.patch
+    patch-qtwebengine-patch-zlib.diff # Backport fix for https://bugreports.qt.io/browse/QTBUG-138486
+    patch-qtwebengine-crc32c-arm64.diff
+  )
+
+  if [ "$(uname)" == "Darwin" ]
+  then
+    qtwebengine_patches+=(
+      patch-qtwebengine-libc++19.diff
+      patch-qtwebengine-src_3rdparty_chromium_third__party_perfetto_include_perfetto_tracing_internal_track__event__data__source.h.diff
+      patch-qtwebengine-src_3rdparty_chromium_third__party_blink_renderer_platform_wtf_hash__table.h.diff
+    )
+  fi
+
   # Apply patches
   pushd $src_dir
-  patch_count=`ls -1 $script_dir/patches/*.patch 2>/dev/null | wc -l`
-  if [ $patch_count != 0 ]
+
+  qtlocation_patch_count=${#qtlocation_patches[@]}
+  echo "Found $qtlocation_patch_count qtlocation patches"
+
+  if [ $qtlocation_patch_count != 0 ]
   then
+    echo "Found $qtwebengine_patch_count qtlocation patches"
+
     echo "Cloning qtlocation so that patches can be applied with git"
     rm -r qtlocation
     git clone \
@@ -404,6 +442,18 @@ then
       --shallow-submodules \
       --filter=blob:none \
       https://github.com/qt/qtlocation.git -b v5.15.18-lts-lgpl qtlocation
+
+    for patch_file in "${qtlocation_patches[@]}"; do
+      echo "Applying $patch_file"
+      git apply --ignore-whitespace $script_dir/patches/${patch_file}
+    done
+  fi
+
+  qtwebengine_patch_count=${#qtwebengine_patches[@]}
+  echo "Found $qtwebengine_patch_count qtwebengine patches"
+
+  if [ $qtwebengine_patch_count != 0 ]
+  then
     echo "Cloning qtwebengine so that patches can be applied with git"
     rm -r qtwebengine
     git clone \
@@ -413,9 +463,22 @@ then
       --shallow-submodules \
       --filter=blob:none \
       https://github.com/qt/qtwebengine.git -b v5.15.19-lts qtwebengine
-    echo "Found $patch_count patches"
-    git apply --ignore-whitespace $script_dir/patches/*.patch
+
+    for patch_file in "${qtwebengine_patches[@]}"; do
+      echo "Applying $patch_file"
+      git apply --ignore-whitespace $script_dir/patches/${patch_file}
+    done
+
   fi
+
+  patch_count=${#patches[@]}
+  echo "Found $patch_count patches"
+
+  for patch_file in "${patches[@]}"; do
+      echo "Applying $patch_file"
+    git apply --ignore-whitespace $script_dir/patches/${patch_file}
+  done
+
   popd
 
 fi

--- a/Build-qt.sh
+++ b/Build-qt.sh
@@ -402,14 +402,14 @@ then
     CVE-2025-23050-qtconnectivity-5.15.diff
   )
   qtlocation_patches=(
-    0001-qtlocation-clang16.patch
+    # 0001-qtlocation-clang16.patch
     patch-qtlocation-mbgl-unique_any.hpp.diff
     patch-qtlocation-narrowing-const-reference.diff # https://trac.macports.org/ticket/73016
   )
 
   qtwebengine_patches=(
-    0002-qtwebengine-ninja1.12.patch
-    0003-qtwebengine-clang16.patch
+    # 0002-qtwebengine-ninja1.12.patch
+    # 0003-qtwebengine-clang16.patch
     patch-qtwebengine-patch-zlib.diff # Backport fix for https://bugreports.qt.io/browse/QTBUG-138486
     patch-qtwebengine-crc32c-arm64.diff
   )

--- a/patches/0003-qtwebengine-clang16.patch
+++ b/patches/0003-qtwebengine-clang16.patch
@@ -11,50 +11,6 @@ index 3abf0ba03b0..d88a82a2eec 100644
  typedef unsigned char  Byte;  /* 8 bits */
  #endif
  typedef unsigned int   uInt;  /* 16 bits or more */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-ft.cc b/qtwebengine/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-ft.cc
-index 2680873c279..21cbe73f52d 100644
---- a/qtwebengine/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-ft.cc
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-ft.cc
-@@ -729,8 +729,9 @@ hb_ft_face_create_referenced (FT_Face ft_face)
- }
- 
- static void
--hb_ft_face_finalize (FT_Face ft_face)
-+hb_ft_face_finalize (void *arg)
- {
-+  FT_Face ft_face = (FT_Face) arg;
-   hb_face_destroy ((hb_face_t *) ft_face->generic.data);
- }
- 
-@@ -762,7 +763,7 @@ hb_ft_face_create_cached (FT_Face ft_face)
-       ft_face->generic.finalizer (ft_face);
- 
-     ft_face->generic.data = hb_ft_face_create (ft_face, nullptr);
--    ft_face->generic.finalizer = (FT_Generic_Finalizer) hb_ft_face_finalize;
-+    ft_face->generic.finalizer = hb_ft_face_finalize;
-   }
- 
-   return hb_face_reference ((hb_face_t *) ft_face->generic.data);
-@@ -949,8 +950,9 @@ get_ft_library ()
- }
- 
- static void
--_release_blob (FT_Face ft_face)
-+_release_blob (void *arg)
- {
-+  FT_Face ft_face = (FT_Face) arg;
-   hb_blob_destroy ((hb_blob_t *) ft_face->generic.data);
- }
- 
-@@ -1032,7 +1034,7 @@ hb_ft_font_set_funcs (hb_font_t *font)
- #endif
- 
-   ft_face->generic.data = blob;
--  ft_face->generic.finalizer = (FT_Generic_Finalizer) _release_blob;
-+  ft_face->generic.finalizer = _release_blob;
- 
-   _hb_ft_font_set_funcs (font, ft_face, true);
-   hb_ft_font_set_load_flags (font, FT_LOAD_DEFAULT | FT_LOAD_NO_HINTING);
 diff --git a/qtwebengine/src/3rdparty/chromium/v8/src/base/bit-field.h b/qtwebengine/src/3rdparty/chromium/v8/src/base/bit-field.h
 index ca5fb459210..50f16262e66 100644
 --- a/qtwebengine/src/3rdparty/chromium/v8/src/base/bit-field.h

--- a/patches/0004-qtbase-tahoe-no-agl-framework.patch
+++ b/patches/0004-qtbase-tahoe-no-agl-framework.patch
@@ -1,0 +1,21 @@
+--- a/qtbase/mkspecs/common/mac.conf
++++ b/qtbase/mkspecs/common/mac.conf
+@@ -18,8 +18,7 @@ QMAKE_LIBDIR            =
+ 
+ # sdk.prf will prefix the proper SDK sysroot
+ QMAKE_INCDIR_OPENGL     = \
+-    /System/Library/Frameworks/OpenGL.framework/Headers \
+-    /System/Library/Frameworks/AGL.framework/Headers/
++    /System/Library/Frameworks/OpenGL.framework/Headers
+ 
+ QMAKE_FIX_RPATH         = install_name_tool -id
+ 
+@@ -30,7 +29,7 @@ QMAKE_LFLAGS_REL_RPATH  =
+ QMAKE_REL_RPATH_BASE    = @loader_path
+ 
+ QMAKE_LIBS_DYNLOAD      =
+-QMAKE_LIBS_OPENGL       = -framework OpenGL -framework AGL
++QMAKE_LIBS_OPENGL       = -framework OpenGL
+ QMAKE_LIBS_THREAD       =
+ 
+ QMAKE_INCDIR_WAYLAND    =

--- a/patches/CVE-2025-23050-qtconnectivity-5.15.diff
+++ b/patches/CVE-2025-23050-qtconnectivity-5.15.diff
@@ -1,0 +1,223 @@
+From bcea4646325b3bc526b8bfaee0bdd795218e3658 Mon Sep 17 00:00:00 2001
+From: Ivan Solovev <ivan.solovev@qt.io>
+Date: Thu, 02 Jan 2025 16:48:49 +0100
+Subject: [PATCH] QLowEnergyControllerPrivateBluez: guard against malformed replies
+
+The QLowEnergyControllerPrivateBluez::l2cpReadyRead() slot reads the
+data from a Bluetooth L2CAP socket and then tries to process it
+according to ATT protocol specs.
+
+However, the code was missing length and sanity checks at some
+codepaths in processUnsolicitedReply() and processReply() helper
+methods, simply relying on the data to be in the proper format.
+
+This patch adds some minimal checks to make sure that we do not read
+past the end of the received array and do not divide by zero.
+
+This problem was originally pointed out by Marc Mutz in an unrelated
+patch.
+
+Conflict resolution for 5.15: adjusted the patch to the fact that
+there is no QBluezConst::AttCommand enum in this branch, and the
+code uses quint8 to represent the ATT commands. This required to
+change the debug message in reportMalformedData() function.
+
+Change-Id: I8dcfe031f70ad61fa3d87dc9d771c3fabc6d0edc
+Reviewed-by: Alex Blasche <alexander.blasche@qt.io>
+Reviewed-by: Juha Vuolle <juha.vuolle@qt.io>
+(cherry picked from commit aecbd657c841a2a8c74631ceac96b8ff1f03ab5c)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 53e991671f725c136e9aa824c59ec13934c63fb4)
+(cherry picked from commit 465e3f3112a9c158aa6dd2f8b9439ae6c2de336f)
+(cherry picked from commit 88c30a23dcff5e7c16a54f93accf743847e22617)
+---
+
+diff --git a/qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp b/qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp
+index fcb497d..9f9246d 100644
+--- qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp.orig
++++ qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp
+@@ -179,12 +179,13 @@
+     return QBluetoothUuid(qtdst);
+ }
+
+-static void dumpErrorInformation(const QByteArray &response)
++/* returns false if the format is incorrect */
++static bool dumpErrorInformation(const QByteArray &response)
+ {
+     const char *data = response.constData();
+     if (response.size() != 5 || data[0] != ATT_OP_ERROR_RESPONSE) {
+         qCWarning(QT_BT_BLUEZ) << QLatin1String("Not a valid error response");
+-        return;
++        return false;
+     }
+
+     quint8 lastCommand = data[1];
+@@ -238,6 +239,8 @@
+     qCDebug(QT_BT_BLUEZ) << "Error1:" << errorString
+              << "last command:" << hex << lastCommand
+              << "handle:" << handle;
++
++    return true;
+ }
+
+ static int getUuidSize(const QBluetoothUuid &uuid)
+@@ -1014,6 +1017,7 @@
+ {
+     Q_ASSERT(charData);
+     Q_ASSERT(data);
++    Q_ASSERT(elementLength >= 5);
+
+     QLowEnergyHandle attributeHandle = bt_get_le16(&data[0]);
+     charData->properties =
+@@ -1022,7 +1026,7 @@
+
+     if (elementLength == 7) // 16 bit uuid
+         charData->uuid = QBluetoothUuid(bt_get_le16(&data[5]));
+-    else
++    else if (elementLength == 21) // 128 bit uuid
+         charData->uuid = convert_uuid128((quint128 *)&data[5]);
+
+     qCDebug(QT_BT_BLUEZ) << "Found handle:" << hex << attributeHandle
+@@ -1039,6 +1043,7 @@
+ {
+     Q_ASSERT(foundServices);
+     Q_ASSERT(data);
++    Q_ASSERT(elementLength >= 6);
+
+     QLowEnergyHandle attributeHandle = bt_get_le16(&data[0]);
+
+@@ -1048,9 +1053,14 @@
+     // data[2] -> included service start handle
+     // data[4] -> included service end handle
+
++    // TODO: Spec v. 5.3, Vol. 3, Part G, 4.5.1 mentions that only
++    // 16-bit UUID can be returned here. If the UUID is 128-bit,
++    // then it is omitted from the response, and should be requested
++    // separately with the ATT_READ_REQ command.
++
+     if (elementLength == 8) //16 bit uuid
+         foundServices->append(QBluetoothUuid(bt_get_le16(&data[6])));
+-    else
++    else if (elementLength == 22) // 128 bit uuid
+         foundServices->append(convert_uuid128((quint128 *) &data[6]));
+
+     qCDebug(QT_BT_BLUEZ) << "Found included service: " << hex
+@@ -1059,17 +1069,29 @@
+     return attributeHandle;
+ }
+
++Q_DECL_COLD_FUNCTION
++static void reportMalformedData(quint8 cmd, const QByteArray &response)
++{
++    qCDebug(QT_BT_BLUEZ, "Command 0x%X malformed data: %s", cmd,
++            response.toHex().constData());
++}
++
+ void QLowEnergyControllerPrivateBluez::processReply(
+         const Request &request, const QByteArray &response)
+ {
+     Q_Q(QLowEnergyController);
+
++    // We already have an isEmpty() check at the only calling site that reads
++    // incoming data, so Q_ASSERT is enough.
++    Q_ASSERT(!response.isEmpty());
++
+     quint8 command = response.constData()[0];
+
+     bool isErrorResponse = false;
+     // if error occurred 2. byte is previous request type
+     if (command == ATT_OP_ERROR_RESPONSE) {
+-        dumpErrorInformation(response);
++        if (!dumpErrorInformation(response))
++            return;
+         command = response.constData()[1];
+         isErrorResponse = true;
+     }
+@@ -1084,6 +1106,10 @@
+             break;
+         }
+
++        if (response.size() < 3) {
++            reportMalformedData(command, response);
++            break;
++        }
+         const char *data = response.constData();
+         quint16 mtu = bt_get_le16(&data[1]);
+         mtuSize = mtu;
+@@ -1111,8 +1137,15 @@
+             break;
+         }
+
++        // response[1] == elementLength. According to the spec it should be
++        // at least 4 bytes. See Spec v5.3, Vol 3, Part F, 3.4.4.10
++        if (response.size() < 2 || response[1] < 4) {
++            reportMalformedData(command, response);
++            break;
++        }
++
+         QLowEnergyHandle start = 0, end = 0;
+-        const quint16 elementLength = response.constData()[1];
++        const quint16 elementLength = response.constData()[1]; // value checked above
+         const quint16 numElements = (response.size() - 2) / elementLength;
+         quint16 offset = 2;
+         const char *data = response.constData();
+@@ -1190,16 +1223,25 @@
+         }
+
+         /* packet format:
+-         * if GATT_CHARACTERISTIC discovery
++         * if GATT_CHARACTERISTIC discovery (Spec 5.3, Vol. 3, Part G, 4.6)
+          *      <opcode><elementLength>
+          *          [<handle><property><charHandle><uuid>]+
++         * The minimum elementLength is 7 bytes (uuid is always included)
+          *
+-         * if GATT_INCLUDE discovery
++         * if GATT_INCLUDE discovery (Spec 5.3, Vol. 3, Part G, 4.5.1)
+          *      <opcode><elementLength>
+          *          [<handle><startHandle_included><endHandle_included><uuid>]+
++         *  The minimum elementLength is 6 bytes (uuid can be omitted).
+          *
+          *  The uuid can be 16 or 128 bit.
+          */
++
++        const quint8 minimumElementLength = attributeType == GATT_CHARACTERISTIC ? 7 : 6;
++        if (response.size() < 2 || response[1] < minimumElementLength) {
++            reportMalformedData(command, response);
++            break;
++        }
++
+         QLowEnergyHandle lastHandle;
+         const quint16 elementLength = response.constData()[1];
+         const quint16 numElements = (response.size() - 2) / elementLength;
+@@ -1401,6 +1443,12 @@
+             break;
+         }
+
++        // Spec 5.3, Vol. 3, Part F, 3.4.3.2
++        if (response.size() < 6) {
++            reportMalformedData(command, response);
++            break;
++        }
++
+         const quint8 format = response[1];
+         quint16 elementLength;
+         switch (format) {
+@@ -1831,8 +1879,17 @@
+
+ void QLowEnergyControllerPrivateBluez::processUnsolicitedReply(const QByteArray &payload)
+ {
++    Q_ASSERT(!payload.isEmpty());
++
+     const char *data = payload.constData();
+-    bool isNotification = (data[0] == ATT_OP_HANDLE_VAL_NOTIFICATION);
++    const quint8 command = data[0];
++    bool isNotification = (command == ATT_OP_HANDLE_VAL_NOTIFICATION);
++
++    if (payload.size() < 3) {
++        reportMalformedData(command, payload);
++        return;
++    }
++
+     const QLowEnergyHandle changedHandle = bt_get_le16(&data[1]);
+
+     if (QT_BT_BLUEZ().isDebugEnabled()) {

--- a/patches/CVE-2025-23050-qtconnectivity-5.15.diff
+++ b/patches/CVE-2025-23050-qtconnectivity-5.15.diff
@@ -34,8 +34,8 @@ Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
 
 diff --git a/qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp b/qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp
 index fcb497d..9f9246d 100644
---- qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp.orig
-+++ qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp
+--- a/qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp
++++ b/qtconnectivity/src/bluetooth/qlowenergycontroller_bluez.cpp
 @@ -179,12 +179,13 @@
      return QBluetoothUuid(qtdst);
  }

--- a/patches/CVE-2025-30348-qtbase-5.15.diff
+++ b/patches/CVE-2025-30348-qtbase-5.15.diff
@@ -1,0 +1,156 @@
+From 16918c1df3e709df2a97281e3825d94c84edb668 Mon Sep 17 00:00:00 2001
+From: Christian Ehrlicher <ch.ehrlicher@gmx.de>
+Date: Tue, 06 Aug 2024 22:39:44 +0200
+Subject: [PATCH] XML/QDom: speedup encodeText()
+
+The code copied the whole string, then replaced parts inline, at
+the cost of relocating everything beyond, at each replacement.
+Instead, copy character by character (in chunks where possible)
+and append replacements as we skip what they replace.
+
+Manual conflict resolution for 6.5:
+- This is a manual cherry-pick. The original change was only
+  picked to 6.8, but the quadratic behavior is present in Qt 5, too.
+- Changed Task-number to Fixes: because this is the real fix;
+  the QString change, 315210de916d060c044c01e53ff249d676122b1b,
+  was unrelated to the original QTBUG-127549.
+
+Manual conflcit resolution for 5.15:
+- Kept/re-added QTextCodec::canEncode() check
+- Ported from Qt 6 to 5, to wit:
+  - qsizetype -> int
+  - QStringView::first/sliced(n) -> left/mid(n)
+    (these functions are clearly called in-range, so the widened
+    contract of the Qt 5 functions doesn't matter)
+- Ported from C++17- and C++14-isms to C++11:
+  - replaced polymorphic lambda with a normal one (this requires
+    rewriting the !canEncode() branch to use QByteArray/QLatin1String
+    instead of QString)
+- As a drive-by, corrected the indentation of the case labels to
+  horizontally align existing code (and follow Qt style)
+
+Fixes: QTBUG-127549
+Change-Id: I368482859ed0c4127f1eec2919183711b5488ada
+Reviewed-by: Edward Welbourne <edward.welbourne@qt.io>
+(cherry picked from commit 2ce08e3671b8d18b0284447e5908ce15e6e8f80f)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 225e235cf966a44af23dbe9aaaa2fd20ab6430ee)
+Reviewed-by: Fabian Kosmale <fabian.kosmale@qt.io>
+(cherry picked from commit 905a5bd421efff6a1d90b6140500d134d32ca745)
+---
+
+diff --git a/qtbase/src/xml/dom/qdom.cpp b/qtbase/src/xml/dom/qdom.cpp
+index 872221c..bf70477 100644
+--- qtbase/src/xml/dom/qdom.cpp.orig
++++ qtbase/src/xml/dom/qdom.cpp
+@@ -3676,59 +3676,67 @@
+     const QTextCodec *const codec = s.codec();
+     Q_ASSERT(codec);
+ #endif
+-    QString retval(str);
+-    int len = retval.length();
+-    int i = 0;
++    QString retval;
++    int start = 0;
++    auto appendToOutput = [&](int cur, QLatin1String replacement)
++    {
++        if (start < cur) {
++            retval.reserve(str.size() + replacement.size());
++            retval.append(QStringView(str).left(cur).mid(start));
++        }
++        // Skip over str[cur], replaced by replacement
++        start = cur + 1;
++        retval.append(replacement);
++    };
+
+-    while (i < len) {
+-        const QChar ati(retval.at(i));
+-
+-        if (ati == QLatin1Char('<')) {
+-            retval.replace(i, 1, QLatin1String("&lt;"));
+-            len += 3;
+-            i += 4;
+-        } else if (encodeQuotes && (ati == QLatin1Char('"'))) {
+-            retval.replace(i, 1, QLatin1String("&quot;"));
+-            len += 5;
+-            i += 6;
+-        } else if (ati == QLatin1Char('&')) {
+-            retval.replace(i, 1, QLatin1String("&amp;"));
+-            len += 4;
+-            i += 5;
+-        } else if (ati == QLatin1Char('>') && i >= 2 && retval[i - 1] == QLatin1Char(']') && retval[i - 2] == QLatin1Char(']')) {
+-            retval.replace(i, 1, QLatin1String("&gt;"));
+-            len += 3;
+-            i += 4;
+-        } else if (performAVN &&
+-                   (ati == QChar(0xA) ||
+-                    ati == QChar(0xD) ||
+-                    ati == QChar(0x9))) {
+-            const QString replacement(QLatin1String("&#x") + QString::number(ati.unicode(), 16) + QLatin1Char(';'));
+-            retval.replace(i, 1, replacement);
+-            i += replacement.length();
+-            len += replacement.length() - 1;
+-        } else if (encodeEOLs && ati == QChar(0xD)) {
+-            retval.replace(i, 1, QLatin1String("&#xd;")); // Replace a single 0xD with a ref for 0xD
+-            len += 4;
+-            i += 5;
+-        } else {
++    const int len = str.size();
++    for (int cur = 0; cur < len; ++cur) {
++        switch (const char16_t ati = str[cur].unicode()) {
++        case u'<':
++            appendToOutput(cur, QLatin1String("&lt;"));
++            break;
++        case u'"':
++            if (encodeQuotes)
++                appendToOutput(cur, QLatin1String("&quot;"));
++            break;
++        case u'&':
++            appendToOutput(cur, QLatin1String("&amp;"));
++            break;
++        case u'>':
++            if (cur >= 2 && str[cur - 1] == u']' && str[cur - 2] == u']')
++                appendToOutput(cur, QLatin1String("&gt;"));
++            break;
++        case u'\r':
++            if (performAVN || encodeEOLs)
++                appendToOutput(cur, QLatin1String("&#xd;"));    // \r == 0x0d
++            break;
++        case u'\n':
++            if (performAVN)
++                appendToOutput(cur, QLatin1String("&#xa;"));    // \n == 0x0a
++            break;
++        case u'\t':
++            if (performAVN)
++                appendToOutput(cur, QLatin1String("&#x9;"));    // \t == 0x09
++            break;
++        default:
+ #if QT_CONFIG(textcodec)
+             if(codec->canEncode(ati))
+-                ++i;
++                ; // continue
+             else
+ #endif
+             {
+                 // We have to use a character reference to get it through.
+-                const ushort codepoint(ati.unicode());
+-                const QString replacement(QLatin1String("&#x") + QString::number(codepoint, 16) + QLatin1Char(';'));
+-                retval.replace(i, 1, replacement);
+-                i += replacement.length();
+-                len += replacement.length() - 1;
++                const QByteArray replacement = "&#x" + QByteArray::number(uint{ati}, 16) + ';';
++                appendToOutput(cur, QLatin1String{replacement});
+             }
++            break;
+         }
+     }
+-
+-    return retval;
++    if (start > 0) {
++        retval.append(QStringView(str).left(len).mid(start));
++        return retval;
++    }
++    return str;
+ }
+
+ void QDomAttrPrivate::save(QTextStream& s, int, int) const

--- a/patches/CVE-2025-30348-qtbase-5.15.diff
+++ b/patches/CVE-2025-30348-qtbase-5.15.diff
@@ -41,8 +41,8 @@ Reviewed-by: Fabian Kosmale <fabian.kosmale@qt.io>
 
 diff --git a/qtbase/src/xml/dom/qdom.cpp b/qtbase/src/xml/dom/qdom.cpp
 index 872221c..bf70477 100644
---- qtbase/src/xml/dom/qdom.cpp.orig
-+++ qtbase/src/xml/dom/qdom.cpp
+--- a/qtbase/src/xml/dom/qdom.cpp
++++ b/qtbase/src/xml/dom/qdom.cpp
 @@ -3676,59 +3676,67 @@
      const QTextCodec *const codec = s.codec();
      Q_ASSERT(codec);

--- a/patches/CVE-2025-4211-qtbase-5.15.diff
+++ b/patches/CVE-2025-4211-qtbase-5.15.diff
@@ -40,8 +40,8 @@ Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
 
 diff --git a/qtbase/src/corelib/io/qfilesystemengine_win.cpp b/qtbase/src/corelib/io/qfilesystemengine_win.cpp
 index 75c661f..37a400f 100644
---- qtbase/src/corelib/io/qfilesystemengine_win.cpp.orig
-+++ qtbase/src/corelib/io/qfilesystemengine_win.cpp
+--- a/qtbase/src/corelib/io/qfilesystemengine_win.cpp
++++ b/qtbase/src/corelib/io/qfilesystemengine_win.cpp
 @@ -1390,7 +1390,15 @@
      QString ret;
  #ifndef Q_OS_WINRT

--- a/patches/CVE-2025-4211-qtbase-5.15.diff
+++ b/patches/CVE-2025-4211-qtbase-5.15.diff
@@ -1,0 +1,61 @@
+From 3d20cd0105c2ae06605c5078e7675e200f1a001a Mon Sep 17 00:00:00 2001
+From: Mårten Nordheim <marten.nordheim@qt.io>
+Date: Mon, 17 Mar 2025 14:22:11 +0100
+Subject: [PATCH] QFileSystemEngine/Win: Use GetTempPath2 when available
+
+Because the documentation for GetTempPath nows says apps should call
+GetTempPath2.[0]
+
+Starting with Windows 11[1], and recently Windows 10[2],
+GetTempPath2 was added. The difference being that elevated
+processes are returned a different directory. Usually
+'C:\Windows\SystemTemp'.
+
+Currently temporary files of an elevated process may be placed in a
+world write-able location. GetTempPath2, by default, but can be
+overridden, places it in a directory that's only accessible by SYSTEM
+and administrators.
+
+[0] https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw#remarks
+[1] https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w
+(Minimum supported client - Windows 11 Build 22000)
+[2] https://blogs.windows.com/windows-insider/2025/03/13/releasing-windows-10-build-19045-5674-to-the-release-preview-channel/
+(This update enables system processes to store temporary files ...)
+
+[ChangeLog][QtCore][Important Behavior Changes] On
+Windows, generating temporary directories for processes with elevated
+privileges may now return a different path with a stricter
+set of permissions. Please consult Microsoft's documentation from when
+they made the same change for the .NET framework:
+https://support.microsoft.com/en-us/topic/gettemppath-changes-in-windows-february-cumulative-update-preview-4cc631fb-9d97-4118-ab6d-f643cd0a7259
+
+Change-Id: I5caf11151fb2f711bbc5599231f140598b3c9d03
+Reviewed-by: Marc Mutz <marc.mutz@qt.io>
+(cherry picked from commit 69633bcb58e681bac5bff3744e5a2352788dc36c)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 6a684a53b371ec483b27bf243af24819be63f85f)
+(cherry picked from commit bbeccc0c22e520f46f0b33e281fa5ac85ac9c727)
+(cherry picked from commit 59d7eb9bbb4f13cccbd9323fd995a8c108b56e60)
+---
+
+diff --git a/qtbase/src/corelib/io/qfilesystemengine_win.cpp b/qtbase/src/corelib/io/qfilesystemengine_win.cpp
+index 75c661f..37a400f 100644
+--- qtbase/src/corelib/io/qfilesystemengine_win.cpp.orig
++++ qtbase/src/corelib/io/qfilesystemengine_win.cpp
+@@ -1390,7 +1390,15 @@
+     QString ret;
+ #ifndef Q_OS_WINRT
+     wchar_t tempPath[MAX_PATH];
+-    const DWORD len = GetTempPath(MAX_PATH, tempPath);
++    using GetTempPathPrototype = DWORD (WINAPI *)(DWORD, LPWSTR);
++    // We try to resolve GetTempPath2 and use that, otherwise fall back to GetTempPath:
++    static GetTempPathPrototype getTempPathW = []() {
++        const HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
++        if (auto *func = QFunctionPointer(GetProcAddress(kernel32, "GetTempPath2W")))
++            return GetTempPathPrototype(func);
++        return GetTempPath;
++    }();
++    const DWORD len = getTempPathW(MAX_PATH, tempPath);
+     if (len) { // GetTempPath() can return short names, expand.
+         wchar_t longTempPath[MAX_PATH];
+         const DWORD longLen = GetLongPathName(tempPath, longTempPath, MAX_PATH);

--- a/patches/CVE-2025-5455-qtbase-5.15.patch
+++ b/patches/CVE-2025-5455-qtbase-5.15.patch
@@ -1,7 +1,7 @@
 diff --git a/qtbase/src/corelib/io/qdataurl.cpp b/qtbase/src/corelib/io/qdataurl.cpp
 index f14d399301f..83e59e3ac00 100644
---- qtbase/src/corelib/io/qdataurl.cpp.orig
-+++ qtbase/src/corelib/io/qdataurl.cpp
+--- a/qtbase/src/corelib/io/qdataurl.cpp
++++ b/qtbase/src/corelib/io/qdataurl.cpp
 @@ -76,10 +76,11 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
          }
 

--- a/patches/CVE-2025-5455-qtbase-5.15.patch
+++ b/patches/CVE-2025-5455-qtbase-5.15.patch
@@ -1,0 +1,20 @@
+diff --git a/qtbase/src/corelib/io/qdataurl.cpp b/qtbase/src/corelib/io/qdataurl.cpp
+index f14d399301f..83e59e3ac00 100644
+--- qtbase/src/corelib/io/qdataurl.cpp.orig
++++ qtbase/src/corelib/io/qdataurl.cpp
+@@ -76,10 +76,11 @@ Q_CORE_EXPORT bool qDecodeDataUrl(const QUrl &uri, QString &mimeType, QByteArray
+         }
+
+         if (data.toLower().startsWith("charset")) {
+-            int i = 7;      // strlen("charset")
+-            while (data.at(i) == ' ')
+-                ++i;
+-            if (data.at(i) == '=')
++            int prefixSize = 7; // strlen("charset")
++            QLatin1String copy(data.constData() + prefixSize, data.size() - prefixSize);
++            while (copy.startsWith(QLatin1String(" ")))
++                copy = copy.mid(1);
++            if (copy.startsWith(QLatin1String("=")))
+                 data.prepend("text/plain;");
+         }
+

--- a/patches/patch-boost-clang16-cpp17-compat.diff
+++ b/patches/patch-boost-clang16-cpp17-compat.diff
@@ -1,0 +1,97 @@
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/config/stdlib/libcpp.hpp	2023-05-02 17:53:04.000000000 +1000
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/config/stdlib/libcpp.hpp	2023-05-02 19:47:26.000000000 +1000
+@@ -166,4 +166,13 @@
+ #  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+ #endif
+ 
++#if _LIBCPP_VERSION >= 15000
++//
++// Unary function is now deprecated in C++11 and later:
++//
++#if __cplusplus >= 201103L
++#define BOOST_NO_CXX98_FUNCTION_BASE
++#endif
++#endif
++
+ //  --- end ---
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/numeric/conversion/detail/int_float_mixture.hpp	2023-03-02 21:34:55.000000000 +1100
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/numeric/conversion/detail/int_float_mixture.hpp	2023-05-02 18:34:05.000000000 +1000
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/int_float_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'IntFloatMixture'
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_integral> int2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, integral_to_float>    int2float_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_integral>    float2int_c ;
+-  typedef mpl::integral_c<int_float_mixture_enum, float_to_float>       float2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_integral> int2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, integral_to_float>    int2float_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_integral>    float2int_c ;
++  typedef boost::integral_constant<int_float_mixture_enum, float_to_float>       float2float_c ;
+ 
+   // Metafunction:
+   //
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/numeric/conversion/detail/sign_mixture.hpp	2023-03-02 21:34:55.000000000 +1100
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/numeric/conversion/detail/sign_mixture.hpp	2023-05-02 18:35:21.000000000 +1000
+@@ -16,15 +16,15 @@
+ #include "boost/numeric/conversion/sign_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'SignMixture'
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
+-  typedef mpl::integral_c<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_unsigned> unsig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_signed>     sig2sig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, signed_to_unsigned>   sig2unsig_c ;
++  typedef boost::integral_constant<sign_mixture_enum, unsigned_to_signed>   unsig2sig_c ;
+ 
+   // Metafunction:
+   //
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/numeric/conversion/detail/udt_builtin_mixture.hpp	2023-03-02 21:34:55.000000000 +1100
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/numeric/conversion/detail/udt_builtin_mixture.hpp	2023-05-02 18:36:25.000000000 +1000
+@@ -15,15 +15,15 @@
+ #include "boost/numeric/conversion/udt_builtin_mixture_enum.hpp"
+ #include "boost/numeric/conversion/detail/meta.hpp"
+ 
+-#include "boost/mpl/integral_c.hpp"
++#include "boost/type_traits/integral_constant.hpp"
+ 
+ namespace boost { namespace numeric { namespace convdetail
+ {
+   // Integral Constants for 'UdtMixture'
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
+-  typedef mpl::integral_c<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_builtin> builtin2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, builtin_to_udt>     builtin2udt_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_builtin>     udt2builtin_c ;
++  typedef boost::integral_constant<udt_builtin_mixture_enum, udt_to_udt>         udt2udt_c ;
+ 
+   // Metafunction:
+   //
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/mpl/aux_/integral_wrapper.hpp
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/deps/boost/1.65.1/include/boost/mpl/aux_/integral_wrapper.hpp
+@@ -56,7 +56,8 @@ struct AUX_WRAPPER_NAME
+ // have to #ifdef here: some compilers don't like the 'N + 1' form (MSVC),
+ // while some other don't like 'value + 1' (Borland), and some don't like
+ // either
+-#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243)
++#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243) \
++    || __clang_major__ >= 16
+  private:
+     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, next_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N + 1)));
+     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, prior_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N - 1)));

--- a/patches/patch-qtlocation-mbgl-unique_any.hpp.diff
+++ b/patches/patch-qtlocation-mbgl-unique_any.hpp.diff
@@ -1,5 +1,5 @@
---- qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp.orig	2023-05-13 13:07:39.000000000 -0400
-+++ qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:07:39.000000000 -0400
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
 @@ -3,6 +3,8 @@
  #include <typeinfo>
  #include <type_traits>

--- a/patches/patch-qtlocation-mbgl-unique_any.hpp.diff
+++ b/patches/patch-qtlocation-mbgl-unique_any.hpp.diff
@@ -1,0 +1,11 @@
+--- qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp.orig	2023-05-13 13:07:39.000000000 -0400
++++ qtlocation/src/3rdparty/mapbox-gl-native/include/mbgl/util/unique_any.hpp	2023-05-13 13:08:21.000000000 -0400
+@@ -3,6 +3,8 @@
+ #include <typeinfo>
+ #include <type_traits>
+ #include <stdexcept>
++#include <utility> // std::move
++
+ namespace mbgl {
+ namespace util {
+ 

--- a/patches/patch-qtlocation-narrowing-const-reference.diff
+++ b/patches/patch-qtlocation-narrowing-const-reference.diff
@@ -1,6 +1,6 @@
 Apply patch from Gentoo bug tracker (https://bugs.gentoo.org/936486) to fix build.
---- qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp.orig
-+++ qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp
+--- a/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp
++++ b/qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp
 @@ -95,7 +95,7 @@ namespace mbgl {
      PointAndCameraDistance project(const Point<float>& point, const mat4& matrix) {
          vec4 pos = {{ point.x, point.y, 0, 1 }};

--- a/patches/patch-qtlocation-narrowing-const-reference.diff
+++ b/patches/patch-qtlocation-narrowing-const-reference.diff
@@ -1,0 +1,12 @@
+Apply patch from Gentoo bug tracker (https://bugs.gentoo.org/936486) to fix build.
+--- qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp.orig
++++ qtlocation/src/3rdparty/mapbox-gl-native/src/mbgl/layout/symbol_projection.cpp
+@@ -95,7 +95,7 @@ namespace mbgl {
+     PointAndCameraDistance project(const Point<float>& point, const mat4& matrix) {
+         vec4 pos = {{ point.x, point.y, 0, 1 }};
+         matrix::transformMat4(pos, pos, matrix);
+-        return {{ static_cast<float>(pos[0] / pos[3]), static_cast<float>(pos[1] / pos[3]) }, pos[3] };
++        return {{ static_cast<float>(pos[0] / pos[3]), static_cast<float>(pos[1] / pos[3]) }, static_cast<float>(pos[3]) };
+     }
+
+     float evaluateSizeForFeature(const ZoomEvaluatedSize& zoomEvaluatedSize, const PlacedSymbol& placedSymbol) {

--- a/patches/patch-qtwebengine-crc32c-arm64.diff
+++ b/patches/patch-qtwebengine-crc32c-arm64.diff
@@ -5,8 +5,8 @@ Fixes:
 
 error: always_inline function 'vmull_p64' requires target feature 'aes', but would be inlined into function 'ExtendArm64' that is compiled without support for 'aes'
 
---- qtwebengine/src/3rdparty/chromium/third_party/crc32c/BUILD.gn.orig	2025-04-23 12:00:55
-+++ qtwebengine/src/3rdparty/chromium/third_party/crc32c/BUILD.gn	2025-09-22 22:17:28
+--- a/qtwebengine/src/3rdparty/chromium/third_party/crc32c/BUILD.gn	2025-04-23 12:00:55
++++ b/qtwebengine/src/3rdparty/chromium/third_party/crc32c/BUILD.gn	2025-09-22 22:17:28
 @@ -122,6 +122,10 @@
          "-target-feature",
          "-Xclang",

--- a/patches/patch-qtwebengine-crc32c-arm64.diff
+++ b/patches/patch-qtwebengine-crc32c-arm64.diff
@@ -1,0 +1,20 @@
+See: https://chromium-review.googlesource.com/c/chromium/qtwebengine/src/+/4137218
+
+Fixes:
+../../3rdparty/chromium/third_party/crc32c/qtwebengine/src/qtwebengine/src/crc32c_arm64.cc:87:20:
+
+error: always_inline function 'vmull_p64' requires target feature 'aes', but would be inlined into function 'ExtendArm64' that is compiled without support for 'aes'
+
+--- qtwebengine/src/3rdparty/chromium/third_party/crc32c/BUILD.gn.orig	2025-04-23 12:00:55
++++ qtwebengine/src/3rdparty/chromium/third_party/crc32c/BUILD.gn	2025-09-22 22:17:28
+@@ -122,6 +122,10 @@
+         "-target-feature",
+         "-Xclang",
+         "+crypto",
++        "-Xclang",
++        "-target-feature",
++        "-Xclang",
++        "+aes",
+       ]
+     } else {
+       cflags = [ "-march=armv8-a+crc+crypto" ]

--- a/patches/patch-qtwebengine-libc++19.diff
+++ b/patches/patch-qtwebengine-libc++19.diff
@@ -23,8 +23,8 @@ Date:   2023-08-17T13:50:11-07:00
     Auto-Submit: Andrey Kosyakov <caseq@chromium.org>
     Cr-Commit-Position: refs/heads/main@{#89559}
 
---- qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.cc.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.cc
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.cc	  2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.cc
 @@ -27,7 +27,7 @@ bool isSpaceOrNewLine(UChar c) {
    return isASCII(c) && c <= ' ' && (c == ' ' || (c <= 0xD && c >= 0x9));
  }
@@ -54,8 +54,8 @@ Date:   2023-08-17T13:50:11-07:00
  }
  
  std::string String16::utf8() const {
---- qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.h.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.h
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.h	2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.h
 @@ -6,6 +6,8 @@
  #define V8_INSPECTOR_STRING_16_H_
  
@@ -102,8 +102,8 @@ Date:   2023-08-17T13:50:11-07:00
                                          size_t length);
  
    std::size_t hash() const {
---- qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.cc.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.cc
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.cc	2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.cc
 @@ -12,7 +12,7 @@ namespace {
  
  namespace v8_inspector {
@@ -131,8 +131,8 @@ Date:   2023-08-17T13:50:11-07:00
    size_t utf16Length = bufferCurrent - bufferStart;
    return std::basic_string<UChar>(bufferStart, bufferStart + utf16Length);
  }
---- qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.h.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.h
+--- a/qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.h	2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.h
 @@ -5,14 +5,16 @@
  #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
  #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
@@ -152,8 +152,8 @@ Date:   2023-08-17T13:50:11-07:00
  }  // namespace v8_inspector
  
  #endif  // V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
---- qtwebengine/src/3rdparty/chromium/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc
+--- a/qtwebengine/src/3rdparty/chromium/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc	2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc
 @@ -11,13 +11,16 @@ std::string UTF16ToUTF8(span<uint16_t> in) {
  namespace v8_crdtp {
  

--- a/patches/patch-qtwebengine-libc++19.diff
+++ b/patches/patch-qtwebengine-libc++19.diff
@@ -1,0 +1,176 @@
+Obtained from:	https://chromium.googlesource.com/v8/v8.git/+/182d9c05e78b1ddb1cb8242cd3628a7855a0336f
+
+commit 182d9c05e78b1ddb1cb8242cd3628a7855a0336f
+Author: Andrey Kosyakov <caseq@chromium.org>
+Date:   2023-08-17T13:50:11-07:00
+
+    Define UChar as char16_t
+    
+    We used to have UChar defined as uint16_t which does not go along
+    with STL these days if you try to have an std::basic_string<> of it,
+    as there are no standard std::char_traits<> specialization for uint16_t.
+    
+    This switches UChar to char16_t where practical, introducing a few
+    compatibility shims to keep CL size small, as (1) this would likely
+    have to be back-ported and (2) crdtp extensively uses uint16_t for
+    wide chars.
+    
+    Bug: b:296390693
+    Change-Id: I66a32d8f0050915225b187de56896c26dd76163d
+    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4789966
+    Reviewed-by: Jaroslav Sevcik <jarin@chromium.org>
+    Commit-Queue: Jaroslav Sevcik <jarin@chromium.org>
+    Auto-Submit: Andrey Kosyakov <caseq@chromium.org>
+    Cr-Commit-Position: refs/heads/main@{#89559}
+
+--- qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.cc.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.cc
+@@ -27,7 +27,7 @@ bool isSpaceOrNewLine(UChar c) {
+   return isASCII(c) && c <= ' ' && (c == ' ' || (c <= 0xD && c >= 0x9));
+ }
+ 
+-int64_t charactersToInteger(const UChar* characters, size_t length,
++int64_t charactersToInteger(const uint16_t* characters, size_t length,
+                             bool* ok = nullptr) {
+   std::vector<char> buffer;
+   buffer.reserve(length + 1);
+@@ -50,6 +50,8 @@ String16::String16(const UChar* characters, size_t siz
+ 
+ String16::String16(const UChar* characters, size_t size)
+     : m_impl(characters, size) {}
++String16::String16(const uint16_t* characters, size_t size)
++    : m_impl(reinterpret_cast<const UChar*>(characters), size) {}
+ 
+ String16::String16(const UChar* characters) : m_impl(characters) {}
+ 
+@@ -231,6 +233,10 @@ String16 String16::fromUTF16LE(const UChar* stringStar
+   // No need to do anything on little endian machines.
+   return String16(stringStart, length);
+ #endif  // V8_TARGET_BIG_ENDIAN
++}
++
++String16 String16::fromUTF16LE(const uint16_t* stringStart, size_t length) {
++  return fromUTF16LE(reinterpret_cast<const UChar*>(stringStart), length);
+ }
+ 
+ std::string String16::utf8() const {
+--- qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.h.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/string-16.h
+@@ -6,6 +6,8 @@
+ #define V8_INSPECTOR_STRING_16_H_
+ 
+ #include <stdint.h>
++#include <uchar.h>
++ 
+ #include <cctype>
+ #include <climits>
+ #include <cstring>
+@@ -17,7 +19,7 @@ namespace v8_inspector {
+ 
+ namespace v8_inspector {
+ 
+-using UChar = uint16_t;
++using UChar = char16_t;
+ 
+ class String16 {
+  public:
+@@ -27,6 +29,7 @@ class String16 {
+   String16(const String16&) V8_NOEXCEPT = default;
+   String16(String16&&) V8_NOEXCEPT = default;
+   String16(const UChar* characters, size_t size);
++  String16(const uint16_t* characters, size_t size);
+   V8_EXPORT String16(const UChar* characters);  // NOLINT(runtime/explicit)
+   V8_EXPORT String16(const char* characters);   // NOLINT(runtime/explicit)
+   String16(const char* characters, size_t size);
+@@ -45,7 +48,9 @@ class String16 {
+   int64_t toInteger64(bool* ok = nullptr) const;
+   int toInteger(bool* ok = nullptr) const;
+   String16 stripWhiteSpace() const;
+-  const UChar* characters16() const { return m_impl.c_str(); }
++  const uint16_t* characters16() const {
++    return reinterpret_cast<const uint16_t*>(m_impl.c_str());
++  }
+   size_t length() const { return m_impl.length(); }
+   bool isEmpty() const { return !m_impl.length(); }
+   UChar operator[](size_t index) const { return m_impl[index]; }
+@@ -74,6 +79,8 @@ class String16 {
+   // Instantiates a String16 in native endianness from UTF16 LE.
+   // On Big endian architectures, byte order needs to be flipped.
+   V8_EXPORT static String16 fromUTF16LE(const UChar* stringStart,
++                                        size_t length);
++  V8_EXPORT static String16 fromUTF16LE(const uint16_t* stringStart,
+                                         size_t length);
+ 
+   std::size_t hash() const {
+--- qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.cc.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.cc
+@@ -12,7 +12,7 @@ namespace {
+ 
+ namespace v8_inspector {
+ namespace {
+-using UChar = uint16_t;
++using UChar = char16_t;
+ using UChar32 = uint32_t;
+ 
+ bool isASCII(UChar c) { return !(c & ~0x7F); }
+@@ -389,7 +389,7 @@ std::basic_string<UChar> UTF8ToUTF16(const char* strin
+ 
+ std::basic_string<UChar> UTF8ToUTF16(const char* stringStart, size_t length) {
+   if (!stringStart || !length) return std::basic_string<UChar>();
+-  std::vector<uint16_t> buffer(length);
++  std::vector<UChar> buffer(length);
+   UChar* bufferStart = buffer.data();
+ 
+   UChar* bufferCurrent = bufferStart;
+@@ -398,7 +398,7 @@ std::basic_string<UChar> UTF8ToUTF16(const char* strin
+                          reinterpret_cast<const char*>(stringStart + length),
+                          &bufferCurrent, bufferCurrent + buffer.size(), nullptr,
+                          true) != conversionOK)
+-    return std::basic_string<uint16_t>();
++    return std::basic_string<UChar>();
+   size_t utf16Length = bufferCurrent - bufferStart;
+   return std::basic_string<UChar>(bufferStart, bufferStart + utf16Length);
+ }
+--- qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.h.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/v8/src/inspector/v8-string-conversions.h
+@@ -5,14 +5,16 @@
+ #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+ #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+ 
++#include <uchar.h>
++
+ #include <cstdint>
+ #include <string>
+ 
+ // Conversion routines between UT8 and UTF16, used by string-16.{h,cc}. You may
+ // want to use string-16.h directly rather than these.
+ namespace v8_inspector {
+-std::basic_string<uint16_t> UTF8ToUTF16(const char* stringStart, size_t length);
+-std::string UTF16ToUTF8(const uint16_t* stringStart, size_t length);
++std::basic_string<char16_t> UTF8ToUTF16(const char* stringStart, size_t length);
++std::string UTF16ToUTF8(const char16_t* stringStart, size_t length);
+ }  // namespace v8_inspector
+ 
+ #endif  // V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+--- qtwebengine/src/3rdparty/chromium/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc
+@@ -11,13 +11,16 @@ std::string UTF16ToUTF8(span<uint16_t> in) {
+ namespace v8_crdtp {
+ 
+ std::string UTF16ToUTF8(span<uint16_t> in) {
+-  return v8_inspector::UTF16ToUTF8(in.data(), in.size());
++  return v8_inspector::UTF16ToUTF8(reinterpret_cast<const char16_t*>(in.data()),
++                                   in.size());
+ }
+ 
+ std::vector<uint16_t> UTF8ToUTF16(span<uint8_t> in) {
+-  std::basic_string<uint16_t> utf16 = v8_inspector::UTF8ToUTF16(
++  std::basic_string<char16_t> utf16 = v8_inspector::UTF8ToUTF16(
+       reinterpret_cast<const char*>(in.data()), in.size());
+-  return std::vector<uint16_t>(utf16.begin(), utf16.end());
++  return std::vector<uint16_t>(
++      reinterpret_cast<const uint16_t*>(utf16.data()),
++      reinterpret_cast<const uint16_t*>(utf16.data()) + utf16.size());
+ }
+ 
+ }  // namespace v8_crdtp

--- a/patches/patch-qtwebengine-libpng.diff
+++ b/patches/patch-qtwebengine-libpng.diff
@@ -1,0 +1,67 @@
+From eb486f33ed1109a78f2794c98aad624023ea26ea Mon Sep 17 00:00:00 2001
+From: Anu Aliyas <anu.aliyas@qt.io>
+Date: Tue, 15 Jul 2025 15:02:08 +0200
+Subject: [PATCH] [Backport][libpng] Apply 893b811 from upstream to fix macro
+ issue
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The latest version of Clang changed what macros it predefines on Apple
+targets, causing errors about predefined macros in libpng.
+
+This applies
+https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24
+from upstream, which fixed the issue.
+
+Bug: 1519899
+Change-Id: I98c568083e2784e02c47d611bf957b1373babe0f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5237620
+Auto-Submit: Hans Wennborg <hans@chromium.org>
+Commit-Queue: Leon Scroggins <scroggo@google.com>
+Reviewed-by: Leon Scroggins <scroggo@google.com>
+Cr-Commit-Position: refs/heads/main@{#1252638}
+Task-number: QTBUG-138485
+Reviewed-on: https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/661294
+Reviewed-by: Michael Brüning <michael.bruning@qt.io>
+---
+ chromium/third_party/libpng/README.chromium |  3 +++
+ chromium/third_party/libpng/pngpriv.h       | 14 ++------------
+ 2 files changed, 5 insertions(+), 12 deletions(-)
+
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/libpng/README.chromium b/qtwebengine/src/3rdparty/chromium/third_party/libpng/README.chromium
+index c17fcbfe9fafe75c1faa5c6ca2d937f1b9f08151..761710b8c2a9ba1b806b8c6ff69ac46a74da948f 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/libpng/README.chromium
++++ b/qtwebengine/src/3rdparty/chromium/third_party/libpng/README.chromium
+@@ -22,3 +22,6 @@ Updated to 1.6.37, stripped all unneeded files.
+   running into OOM errors.
+ - Applies the patch from https://github.com/glennrp/libpng/pull/285 to keep
+   clang-cl build working.
++- Applies the commit from
++  https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24
++  to address a build failure with the latest Clang for Apple targets.
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpriv.h b/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpriv.h
+index 583c26f9bdecfc8bf5b885d6b2b6187f9665ff37..9346feeedf09db231b4d1adef71f82619fb7f18e 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpriv.h
++++ b/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpriv.h
+@@ -517,18 +517,8 @@
+     */
+ #  include <float.h>
+
+-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+-   /* We need to check that <math.h> hasn't already been included earlier
+-    * as it seems it doesn't agree with <fp.h>, yet we should really use
+-    * <fp.h> if possible.
+-    */
+-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
+-#      include <fp.h>
+-#    endif
+-#  else
+-#    include <math.h>
+-#  endif
++#  include <math.h>
++
+ #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
+    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
+     * MATH=68881

--- a/patches/patch-qtwebengine-patch-zlib.diff
+++ b/patches/patch-qtwebengine-patch-zlib.diff
@@ -25,10 +25,10 @@ Reviewed-by: Michael Brüning <michael.bruning@qt.io>
  chromium/third_party/zlib/zutil.h | 23 +----------------------
  1 file changed, 1 insertion(+), 22 deletions(-)
 
-diff --git a/chromium/third_party/zlib/zutil.h b/chromium/third_party/zlib/zutil.h
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h b/qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h
 index 6980a5f4ea34464e38040e5cfad5443b6f3684a4..2e2f57665bba81636d27f6fcc7797f424382d1bf 100644
---- qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h.orig
-+++ qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h
++++ b/qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h
 @@ -152,17 +152,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
  #  endif
  #endif

--- a/patches/patch-qtwebengine-patch-zlib.diff
+++ b/patches/patch-qtwebengine-patch-zlib.diff
@@ -1,0 +1,69 @@
+From 1d29d95bf4732a2d6f46547aa2773c9e742ad52e Mon Sep 17 00:00:00 2001
+From: Anu Aliyas <anu.aliyas@qt.io>
+Date: Tue, 15 Jul 2025 14:57:56 +0200
+Subject: [PATCH] [Backport] [zlib][build] Remove fdopen #defines in zutil.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The latest version of Clang changed what macros it predefines on Apple
+targets, causing errors about predefined macros in zlib.
+
+See:
+https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9
+
+Bug: 1519899
+Change-Id: Ie75ef4078f2c86d89ba6c036ddd13e768a40ccbb
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/qtwebengine/src/+/5237020
+Reviewed-by: Adenilson Cavalcanti <cavalcantii@chromium.org>
+Commit-Queue: Hans Wennborg <hans@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1253252}
+Task-number: QTBUG-138486
+Reviewed-on: https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/661289
+Reviewed-by: Michael Brüning <michael.bruning@qt.io>
+---
+ chromium/third_party/zlib/zutil.h | 23 +----------------------
+ 1 file changed, 1 insertion(+), 22 deletions(-)
+
+diff --git a/chromium/third_party/zlib/zutil.h b/chromium/third_party/zlib/zutil.h
+index 6980a5f4ea34464e38040e5cfad5443b6f3684a4..2e2f57665bba81636d27f6fcc7797f424382d1bf 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h.orig
++++ qtwebengine/src/3rdparty/chromium/third_party/zlib/zutil.h
+@@ -152,17 +152,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+-#  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+-#  endif
+ #endif
+
+ #ifdef __acorn
+@@ -185,18 +176,6 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  define OS_CODE 19
+ #endif
+
+-#if defined(_BEOS_) || defined(RISCOS)
+-#  define fdopen(fd,mode) NULL /* No fdopen() */
+-#endif
+-
+-#if (defined(_MSC_VER) && (_MSC_VER > 600)) && !defined __INTERIX
+-#  if defined(_WIN32_WCE)
+-#    define fdopen(fd,mode) NULL /* No fdopen() */
+-#  else
+-#    define fdopen(fd,type)  _fdopen(fd,type)
+-#  endif
+-#endif
+-
+ #if defined(__BORLANDC__) && !defined(MSDOS)
+   #pragma warn -8004
+   #pragma warn -8008

--- a/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_blink_renderer_platform_wtf_hash__table.h.diff
+++ b/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_blink_renderer_platform_wtf_hash__table.h.diff
@@ -1,0 +1,31 @@
+--- qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/hash_table.h.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/hash_table.h
+@@ -1786,7 +1786,7 @@ HashTable<Key, Value, Extractor, HashFunctions, Traits
+     }
+   }
+   table_ = temporary_table;
+-  Allocator::template BackingWriteBarrier(&table_);
++  Allocator::template BackingWriteBarrier<>(&table_);
+ 
+   if (Traits::kEmptyValueIsZero) {
+     memset(original_table, 0, new_table_size * sizeof(ValueType));
+@@ -1844,7 +1844,7 @@ HashTable<Key, Value, Extractor, HashFunctions, Traits
+   // This swaps the newly allocated buffer with the current one. The store to
+   // the current table has to be atomic to prevent races with concurrent marker.
+   AsAtomicPtr(&table_)->store(new_hash_table.table_, std::memory_order_relaxed);
+-  Allocator::template BackingWriteBarrier(&table_);
++  Allocator::template BackingWriteBarrier<>(&table_);
+   table_size_ = new_table_size;
+ 
+   new_hash_table.table_ = old_table;
+@@ -2012,8 +2012,8 @@ void HashTable<Key,
+   // on the mutator thread, which is also the only one that writes to them, so
+   // there is *no* risk of data races when reading.
+   AtomicWriteSwap(table_, other.table_);
+-  Allocator::template BackingWriteBarrier(&table_);
+-  Allocator::template BackingWriteBarrier(&other.table_);
++  Allocator::template BackingWriteBarrier<>(&table_);
++  Allocator::template BackingWriteBarrier<>(&other.table_);
+   if (IsWeak<ValueType>::value) {
+     // Weak processing is omitted when no backing store is present. In case such
+     // an empty table is later on used it needs to be strongified.

--- a/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_blink_renderer_platform_wtf_hash__table.h.diff
+++ b/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_blink_renderer_platform_wtf_hash__table.h.diff
@@ -1,5 +1,5 @@
---- qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/hash_table.h.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/hash_table.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/hash_table.h	2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/hash_table.h
 @@ -1786,7 +1786,7 @@ HashTable<Key, Value, Extractor, HashFunctions, Traits
      }
    }

--- a/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_perfetto_include_perfetto_tracing_internal_track__event__data__source.h.diff
+++ b/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_perfetto_include_perfetto_tracing_internal_track__event__data__source.h.diff
@@ -1,5 +1,5 @@
---- qtwebengine/src/3rdparty/chromium/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h.orig	2024-08-13 14:59:47 UTC
-+++ qtwebengine/src/3rdparty/chromium/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h
+--- a/qtwebengine/src/3rdparty/chromium/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h	2024-08-13 14:59:47 UTC
++++ b/qtwebengine/src/3rdparty/chromium/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h
 @@ -107,7 +107,7 @@ class TrackEventDataSource
    }
  

--- a/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_perfetto_include_perfetto_tracing_internal_track__event__data__source.h.diff
+++ b/patches/patch-qtwebengine-src_3rdparty_chromium_third__party_perfetto_include_perfetto_tracing_internal_track__event__data__source.h.diff
@@ -1,0 +1,47 @@
+--- qtwebengine/src/3rdparty/chromium/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h.orig	2024-08-13 14:59:47 UTC
++++ qtwebengine/src/3rdparty/chromium/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h
+@@ -107,7 +107,7 @@ class TrackEventDataSource
+   }
+ 
+   static void Flush() {
+-    Base::template Trace([](typename Base::TraceContext ctx) { ctx.Flush(); });
++    Base::Trace([](typename Base::TraceContext ctx) { ctx.Flush(); });
+   }
+ 
+   // Determine if tracing for the given static category is enabled.
+@@ -121,7 +121,7 @@ class TrackEventDataSource
+   static bool IsDynamicCategoryEnabled(
+       const DynamicCategory& dynamic_category) {
+     bool enabled = false;
+-    Base::template Trace([&](typename Base::TraceContext ctx) {
++    Base::Trace([&](typename Base::TraceContext ctx) {
+       enabled = IsDynamicCategoryEnabled(&ctx, dynamic_category);
+     });
+     return enabled;
+@@ -428,7 +428,7 @@ class TrackEventDataSource
+                                  const protos::gen::TrackDescriptor& desc) {
+     PERFETTO_DCHECK(track.uuid == desc.uuid());
+     TrackRegistry::Get()->UpdateTrack(track, desc.SerializeAsString());
+-    Base::template Trace([&](typename Base::TraceContext ctx) {
++    Base::Trace([&](typename Base::TraceContext ctx) {
+       TrackEventInternal::WriteTrackDescriptor(
+           track, ctx.tls_inst_->trace_writer.get());
+     });
+@@ -545,7 +545,7 @@ class TrackEventDataSource
+   static void TraceWithInstances(uint32_t instances,
+                                  Lambda lambda) PERFETTO_ALWAYS_INLINE {
+     if (CategoryIndex == TrackEventCategoryRegistry::kDynamicCategoryIndex) {
+-      Base::template TraceWithInstances(instances, std::move(lambda));
++      Base::TraceWithInstances(instances, std::move(lambda));
+     } else {
+       Base::template TraceWithInstances<
+           CategoryTracePointTraits<CategoryIndex>>(instances,
+@@ -560,7 +560,7 @@ class TrackEventDataSource
+       const TrackType& track,
+       std::function<void(protos::pbzero::TrackDescriptor*)> callback) {
+     TrackRegistry::Get()->UpdateTrack(track, std::move(callback));
+-    Base::template Trace([&](typename Base::TraceContext ctx) {
++    Base::Trace([&](typename Base::TraceContext ctx) {
+       TrackEventInternal::WriteTrackDescriptor(
+           track, ctx.tls_inst_->trace_writer.get());
+     });


### PR DESCRIPTION
- Ensures proper detection of the "Desktop OpenGL" backend by removing unnecessary AGL framework linkage.
- Add `-headerpad_max_install_names` to OpenSSL linkage: Addresses errors related to updating install names or rpaths due to insufficient header padding.
- Speed up source downloads of qtlocation and qtwebengine repositories by using shallow clones with minimal history and filtered blobs.
- Updating the `qtwebengine` version to `v5.15.19-lts`.
- Incorporation of multiple patches adapted from macports-ports.
- Addition of verbose flag to git apply for better feedback.

cc: @jamesobutler @ebrahimebrahim